### PR TITLE
feat: update BackPage styles

### DIFF
--- a/packages/app/src/Routes.tsx
+++ b/packages/app/src/Routes.tsx
@@ -9,7 +9,7 @@ import { ArticlePage } from "./pages/ArticlePage";
 
 export const FRONT_PAGE_PATH = "/";
 export const LOCAL_PAGE_PATH = "/local";
-export const CLASSIFIEDS_PAGE_PATH = "/classifieds";
+export const BACK_PAGE_PATH = "/back-page";
 export const DISCOVER_PAGE_PATH = "/discover";
 export const EDITOR_PAGE_PATH = "/editor";
 export const ARTICLE_PAGE_PATH = "/article/";
@@ -19,7 +19,7 @@ const AppRoutes: React.FC = () => {
     <Routes>
       <Route path={FRONT_PAGE_PATH} element={<FrontPage />} />
       <Route path={LOCAL_PAGE_PATH} element={<LocalPage />} />
-      <Route path={CLASSIFIEDS_PAGE_PATH} element={<BackPage />} />
+      <Route path={BACK_PAGE_PATH} element={<BackPage />} />
       <Route path={DISCOVER_PAGE_PATH} element={<DiscoverPage />} />
       <Route path={EDITOR_PAGE_PATH} element={<EditorRoomPage />} />
       <Route path={`${ARTICLE_PAGE_PATH}:id`} element={<ArticlePage />} />

--- a/packages/app/src/components/Masthead.tsx
+++ b/packages/app/src/components/Masthead.tsx
@@ -2,7 +2,7 @@ import { cn } from "../lib/utils";
 import { Newspaper } from "lucide-react";
 import { Link } from "react-router-dom";
 import {
-  CLASSIFIEDS_PAGE_PATH,
+  BACK_PAGE_PATH,
   DISCOVER_PAGE_PATH,
   EDITOR_PAGE_PATH,
   FRONT_PAGE_PATH,
@@ -12,7 +12,7 @@ import {
 const nav = [
   { href: FRONT_PAGE_PATH, label: "Front Page" },
   { href: LOCAL_PAGE_PATH, label: "Local" },
-  { href: CLASSIFIEDS_PAGE_PATH, label: "Back Page" },
+  { href: BACK_PAGE_PATH, label: "Back Page" },
   { href: DISCOVER_PAGE_PATH, label: "Discover" },
   { href: EDITOR_PAGE_PATH, label: "Editor Room" },
 ];

--- a/packages/app/src/components/ui/textarea.tsx
+++ b/packages/app/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Textarea = ({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">): JSX.Element => {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+};
+
+export { Textarea };

--- a/packages/app/src/dummy-data.ts
+++ b/packages/app/src/dummy-data.ts
@@ -138,3 +138,24 @@ export const localNewsSeed: Article[] = [
     title: "Enderman Art Fair Returns",
   },
 ];
+
+export const classifiedsSeed = [
+  {
+    id: "c1",
+    type: "Offer",
+    title: "Free Cats (untamed)",
+    body: "Bring fish and patience. Coords: 88 69 -12.",
+  },
+  {
+    id: "c2",
+    type: "Wanted",
+    title: "Looking for Silk Touch Hoe",
+    body: "Yes, it exists. Trade for name tags.",
+  },
+  {
+    id: "c3",
+    type: "Service",
+    title: "Story Wanted",
+    body: "Report on rail line expansions near Blockhaven.",
+  },
+];

--- a/packages/app/src/pages/BackPage.tsx
+++ b/packages/app/src/pages/BackPage.tsx
@@ -1,30 +1,111 @@
-export function BackPage() {
+import type React from "react";
+
+import { Input } from "../components/ui/input";
+import { Textarea } from "../components/ui/textarea";
+import { Button } from "../components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import { useState } from "react";
+import { cn } from "../lib/utils";
+import { classifiedsSeed } from "../dummy-data";
+
+type Post = { id: string; type: string; title: string; body: string };
+
+export const BackPage = () => {
+  const [posts, setPosts] = useState<Post[]>(classifiedsSeed);
+  const [form, setForm] = useState({ type: "Offer", title: "", body: "" });
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.title || !form.body) return;
+    setPosts((p) => [
+      { id: Math.random().toString(36).slice(2), ...form },
+      ...p,
+    ]);
+    setForm({ type: "Offer", title: "", body: "" });
+  };
+
   return (
-    <section className="rounded-xl bg-panel border border-neutral-200 dark:border-neutral-800 p-6">
-      <h2 className="font-heading text-3xl mb-4">Back Page — Classifieds</h2>
-      <div className="rounded-xl border border-neutral-300 dark:border-neutral-800 p-4">
-        <div className="grid md:grid-cols-[160px_1fr] gap-3">
-          <select className="px-3 py-2 rounded border border-neutral-300 dark:border-neutral-800 bg-panel">
-            <option>Offer</option>
-            <option>Request</option>
-            <option>Service</option>
-          </select>
-          <input placeholder="Title" className="px-3 py-2 rounded border border-neutral-300 dark:border-neutral-800 bg-panel" />
-          <textarea placeholder="Details..." rows={4} className="md:col-span-2 px-3 py-2 rounded border border-neutral-300 dark:border-neutral-800 bg-panel" />
-          <div className="md:col-span-2">
-            <button className="w-full px-3 py-2 bg-neutral-900 text-white rounded font-accent">Submit Listing</button>
-          </div>
-        </div>
+    <div className="gap-6 grid p-4 sm:p-6">
+      <div>
+        <h1 className={cn("font-heading", "text-3xl")}>
+          Back Page — Classifieds
+        </h1>
+        <p
+          className={cn(
+            "font-accent",
+            "text-[10px] text-neutral-700 tracking-widest uppercase"
+          )}
+        >
+          Looking for something, offering a service, or asking for a story
+        </p>
       </div>
-      <div className="grid md:grid-cols-3 gap-4 mt-6">
-        {["OFFER","WANTED","SERVICE"].map((k,i) => (
-          <article key={i} className="bg-panel border border-neutral-300 dark:border-neutral-800 p-4 rounded">
-            <div className="uppercase tracking-[.2em] text-xs text-neutral-500 font-accent">{k}</div>
-            <h3 className="font-heading text-xl">Free Cats (untamed)</h3>
-            <p className="text-text-secondary">Bring fish and patience. Coords: 88 69 -12.</p>
-          </article>
+
+      <Card className="border-neutral-900">
+        <CardHeader>
+          <CardTitle className={cn("font-heading", "text-xl")}>
+            Post a Listing
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="gap-3 grid" onSubmit={submit}>
+            <div className="gap-2 grid sm:grid-cols-3">
+              <select
+                aria-label="Type"
+                className="bg-neutral-50 border border-neutral-900 px-2 py-2 rounded-md"
+                onChange={(e) => setForm({ ...form, type: e.target.value })}
+                value={form.type}
+              >
+                <option>Offer</option>
+                <option>Wanted</option>
+                <option>Service</option>
+              </select>
+              <Input
+                className="border-neutral-900 sm:col-span-2"
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                placeholder="Title"
+                value={form.title}
+              />
+            </div>
+            <Textarea
+              className="border-neutral-900 min-h-28"
+              onChange={(e) => setForm({ ...form, body: e.target.value })}
+              placeholder="Details..."
+              value={form.body}
+            />
+            <Button
+              className={cn("font-accent", "h-9 px-3 text-[10px]")}
+              type="submit"
+            >
+              Submit Listing
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="gap-6 grid md:grid-cols-3">
+        {posts.map((p) => (
+          <div
+            key={p.id}
+            className="bg-neutral-50 border border-neutral-900 p-3"
+          >
+            <div
+              className={cn(
+                "font-accent",
+                "text-[10px] text-neutral-700 tracking-widest uppercase"
+              )}
+            >
+              {p.type}
+            </div>
+            <h3 className={cn("font-heading", "text-xl")}>{p.title}</h3>
+            <p className={"text-[15px] leading-relaxed"}>{p.body}</p>
+          </div>
         ))}
       </div>
-    </section>
+    </div>
   );
-}
+};


### PR DESCRIPTION
This pull request refactors the "Back Page" (formerly "Classifieds") feature by renaming all related constants and navigation, introducing a new data model for classifieds, and implementing a fully interactive classifieds posting and listing UI. It also adds a reusable `Textarea` component for consistent UI across the app.

**Back Page/Classifieds Refactor and Feature Expansion:**

* Renamed all references from `CLASSIFIEDS_PAGE_PATH` to `BACK_PAGE_PATH` in route constants, navigation, and imports for consistency and clarity. [[1]](diffhunk://#diff-484b88a52bd2a6a64ab692674cf7c343ce2e6b82069035d8317ec4ab70bc0033L12-R12) [[2]](diffhunk://#diff-484b88a52bd2a6a64ab692674cf7c343ce2e6b82069035d8317ec4ab70bc0033L22-R22) [[3]](diffhunk://#diff-12ca3d5352126d9dcb88a6a2a01d64604ca9a26e4559f74662398793910eb508L5-R5) [[4]](diffhunk://#diff-12ca3d5352126d9dcb88a6a2a01d64604ca9a26e4559f74662398793910eb508L15-R15)
* Replaced the static and placeholder classifieds UI in `BackPage` with a dynamic, stateful component that displays real classifieds, allows users to post new listings, and uses the new `classifiedsSeed` data. [[1]](diffhunk://#diff-8c45fad623173e6f1522a65bcf4697c57df4eaf624c5816397e5645f46bd6cd0L1-R111) [[2]](diffhunk://#diff-d7e90bdc381b6260ab2a2133551036edb4019f1bca95f42c6d5761cb15357132R141-R161)

**UI Component Improvements:**

* Added a new reusable `Textarea` component in `components/ui/textarea.tsx` for consistent text area styling across the app.

**Data Model Enhancements:**

* Introduced a `classifiedsSeed` array in `dummy-data.ts` to provide initial data for the classifieds section, supporting different types (Offer, Wanted, Service) and more realistic content.