### PR TITLE
add discover page and setwaypoint in cards

### DIFF
--- a/packages/app/src/components/ArticleCard.tsx
+++ b/packages/app/src/components/ArticleCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { ARTICLE_PAGE_PATH } from "@/Routes";
@@ -24,6 +25,7 @@ export const ArticleCard = ({
   article: Article;
   compact?: boolean;
 }) => {
+  const [imgLoaded, setImgLoaded] = useState(false);
   return (
     <article className="relative">
       <h3
@@ -40,14 +42,32 @@ export const ArticleCard = ({
           {article.title}
         </Link>
       </h3>
-      <div className="border border-neutral-900 my-2 overflow-hidden">
+      <div className="border border-neutral-900 my-2 overflow-hidden relative">
+        {/* shimmer placeholder while image loads */}
+        {!imgLoaded && (
+          <div
+            aria-hidden
+            className="absolute inset-0 bg-neutral-200"
+            style={{
+              backgroundImage:
+                'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0) 100%)',
+              backgroundSize: '200% 100%',
+              animation: 'shimmer 1.2s linear infinite',
+            }}
+          />
+        )}
         <img
           alt={article.title}
           src={article.image}
-          className="aspect-video grayscale object-cover w-full"
+          loading="lazy"
+          onLoad={() => setImgLoaded(true)}
+          className={`aspect-video grayscale object-cover w-full transition-opacity duration-500 ${
+            imgLoaded ? "opacity-100" : "opacity-0"
+          }`}
           width={800}
           height={450}
         />
+        <style>{`@keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }`}</style>
       </div>
       <p className={"text-[15px] leading-relaxed text-neutral-800"}>
         {article.excerpt}

--- a/packages/app/src/pages/DiscoverPage.tsx
+++ b/packages/app/src/pages/DiscoverPage.tsx
@@ -1,45 +1,164 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+import { useRecords, useRecord } from "@latticexyz/stash/react";
+import { getRecord } from "@latticexyz/stash/internal";
 
 import { ArticleCard } from "@/components/ArticleCard";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { localNewsSeed, weeklyCurated } from "@/dummy-data";
 import { cn } from "@/lib/utils";
+import { useDustClient } from "@/common/useDustClient";
+import { encodeBlock } from "@dust/world/internal";
+import { stash, tables } from "@/mud/stash";
 
 export const DiscoverPage = () => {
-  const all = useMemo(() => [...weeklyCurated, ...localNewsSeed], []);
+  const { data: dustClient } = useDustClient();
+  const [currentPos, setCurrentPos] = useState<{ x: number; y: number; z: number } | null>(null);
+  // Read posts from on-chain stash
+  const rawPosts = useRecords({ stash, table: tables.Post }) || [];
+
+  // Resolve available categories from on-chain ArticleCategories -> Category table
+  const articleCategories = (useRecord({ stash, table: tables.ArticleCategories, key: {} })
+    ?.value?.map((c: any) => {
+      return getRecord({ stash, table: tables.Category, key: { id: c } })?.value;
+    })
+    .filter((c: any): c is string => !!c) ?? []) as string[];
 
   const [q, setQ] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
+  const [authorFilter, setAuthorFilter] = useState<string>("");
+  const [dateSort, setDateSort] = useState<'newest'|'oldest'>('newest');
 
-  const allCategories = useMemo(() => {
-    const categories = new Set<string>();
-    all.forEach((article) => {
-      article.categories?.forEach((cat) => categories.add(cat));
-    });
-    return Array.from(categories).sort();
-  }, [all]);
+  // Map raw posts into the shape used by ArticleCard
+  const posts = useMemo(() => {
+    return rawPosts
+      .map((r: any) => {
+        const isArticle =
+          getRecord({ stash, table: tables.IsArticle, key: { id: r.id } })
+            ?.value ?? false;
+
+        if (!isArticle) return null;
+
+        const anchorRecord =
+          getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
+          null;
+        const anchor = anchorRecord
+          ? {
+              x: Number(anchorRecord.coordX || 0),
+              y: Number(anchorRecord.coordY || 0),
+              z: Number(anchorRecord.coordZ || 0),
+            }
+          : { x: 0, y: 0, z: 0 };
+
+        const excerpt =
+          typeof r.content === "string"
+            ? (r.content.split("\n\n")[0] || r.content).slice(0, 240)
+            : "";
+
+        return {
+          id: r.id,
+          title: r.title || "Untitled",
+          author: r.owner || "",
+          categories: (r.categories || []).map((c: any) => {
+            const val = getRecord({ stash, table: tables.Category, key: { id: c } })?.value;
+            return val ?? String(c);
+          }).filter(Boolean),
+          city: "",
+          content: (typeof r.content === "string" ? r.content.split("\n\n") : []) as string[],
+          coords: anchor,
+          excerpt,
+          image: r.coverImage || "/assets/placeholder-notext.png",
+          section: "",
+          timestamp: Number(r.createdAt ?? 0),
+        };
+      })
+      .filter(Boolean) as any[];
+  }, [rawPosts]);
 
   const filtered = useMemo(() => {
-    const term = q.toLowerCase();
-    let results = all;
+    const term = q.trim().toLowerCase();
+
+    let results = posts.slice();
 
     if (selectedCategory) {
-      results = results.filter((a) => a.categories?.includes(selectedCategory));
+      results = results.filter((a) => (a.categories || []).includes(selectedCategory));
+    }
+
+    if (authorFilter.trim()) {
+      const af = authorFilter.trim().toLowerCase();
+      results = results.filter((a) => (a.author || "").toLowerCase().includes(af));
     }
 
     if (term) {
       results = results.filter(
         (a) =>
-          a.title.toLowerCase().includes(term) ||
-          (a.excerpt ?? "").toLowerCase().includes(term) ||
-          (a.categories ?? []).some((cat) => cat.toLowerCase().includes(term))
+          (a.title || "").toLowerCase().includes(term) ||
+          (a.excerpt || "").toLowerCase().includes(term) ||
+          (a.categories || []).some((cat: string) => cat.toLowerCase().includes(term))
       );
     }
 
+    // sort by date
+    results.sort((a, b) => {
+      if (dateSort === 'newest') return b.timestamp - a.timestamp;
+      return a.timestamp - b.timestamp;
+    });
+
     return results;
-  }, [all, q, selectedCategory]);
+  }, [posts, q, selectedCategory, authorFilter, dateSort]);
+
+  const distance = (
+    a: { x: number; y: number; z: number },
+    b: { x: number; y: number; z: number }
+  ) => {
+    const dx = a.x - b.x;
+    const dz = a.z - b.z;
+    return Math.round(Math.sqrt(dx * dx + dz * dz));
+  };
+
+  useEffect(() => {
+    (async () => {
+      if (!dustClient) return;
+      try {
+        const pos = await (dustClient as any).provider.request({
+          method: "getPlayerPosition",
+          params: { entity: (dustClient as any).appContext?.userAddress },
+        });
+        if (pos && typeof pos.x === "number") {
+          setCurrentPos({ x: Math.floor(pos.x), y: Math.floor(pos.y), z: Math.floor(pos.z) });
+        }
+      } catch (e) {
+        // ignore
+      }
+    })();
+  }, [dustClient]);
+
+  const handleSetWaypoint = async (article: any) => {
+    if (!dustClient) {
+      alert('Wallet/client not ready');
+      return;
+    }
+    const coords = article.coords;
+    if (!coords || typeof coords.x !== 'number') {
+      alert('Article has no anchor/coordinates to set a waypoint for');
+      return;
+    }
+    try {
+      const bx = Math.floor(coords.x);
+      const by = Math.floor(coords.y);
+      const bz = Math.floor(coords.z);
+      const entityId = encodeBlock([bx, by, bz]);
+
+      await (dustClient as any).provider.request({
+        method: 'setWaypoint',
+        params: { entity: entityId, label: article.title || 'Waypoint' },
+      });
+    } catch (e) {
+      console.warn('Failed to set waypoint', e);
+      alert('Failed to set waypoint');
+    }
+  };
 
   return (
     <div className="gap-6 p-4 sm:p-6 grid">
@@ -48,12 +167,32 @@ export const DiscoverPage = () => {
           <h1 className={cn("font-heading", "text-3xl")}>Discover</h1>
           <p className="text-neutral-700 text-sm">Search all submissions</p>
         </div>
-        <Input
-          className="border-neutral-900 max-w-xs"
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="Search stories..."
-          value={q}
-        />
+        <div className="flex gap-2 items-end">
+          <Input
+            className="border-neutral-900 max-w-xs"
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search stories..."
+            value={q}
+          />
+          <Input
+            className="border-neutral-900 max-w-xs"
+            onChange={(e) => setAuthorFilter(e.target.value)}
+            placeholder="Filter by author..."
+            value={authorFilter}
+          />
+          <select
+            className={cn(
+              "border-input bg-transparent border border-neutral-900",
+              "h-9 rounded-md px-2 text-sm"
+            )}
+            value={dateSort}
+            onChange={(e) => setDateSort(e.target.value as 'newest'|'oldest')}
+            aria-label="Sort by date"
+          >
+            <option value="newest">Newest</option>
+            <option value="oldest">Oldest</option>
+          </select>
+        </div>
       </div>
 
       <div className="flex flex-wrap gap-2">
@@ -65,7 +204,7 @@ export const DiscoverPage = () => {
         >
           All Categories
         </Button>
-        {allCategories.map((category) => (
+        {articleCategories.map((category) => (
           <Button
             key={category}
             className="border-neutral-900"
@@ -84,6 +223,22 @@ export const DiscoverPage = () => {
             {filtered.map((a) => (
               <div key={a.id} className="border-neutral-900 border-t pt-3">
                 <ArticleCard article={a} />
+                <div className={cn("font-accent", "mt-2 text-[10px]")}>
+                  {a.coords && currentPos ? (
+                    <>
+                      Distance: {distance(currentPos, a.coords)} blocks •{" "}
+                    </>
+                  ) : (
+                    a.coords && `x:${a.coords.x} y:${a.coords.y} z:${a.coords.z}`
+                  )}
+                  <button
+                    onClick={() => handleSetWaypoint(a)}
+                    className="underline ml-1"
+                    disabled={!dustClient}
+                  >
+                    Set Waypoint
+                  </button>
+                </div>
               </div>
             ))}
             {filtered.length === 0 && (

--- a/packages/app/src/utils/constants.ts
+++ b/packages/app/src/utils/constants.ts
@@ -1,18 +1,11 @@
 export const POPULAR_PLACES = [
   {
     id: "default-raidguild-forge",
-    name: "Raidguild Forge",
+    name: "RaidGuild",
     coords: { x: 1272, y: 154, z: -930 },
     description:
       "The main RaidGuild Forge Hall - a central hub for crafting and community",
     category: "Base",
-  },
-  {
-    id: "default-arena-eternal",
-    name: "Arena Eternal",
-    coords: { x: -22, y: 75, z: 101 },
-    description: "Community PvP arena",
-    category: "Arena",
   },
   {
     id: "default-perm-town-market",
@@ -20,13 +13,6 @@ export const POPULAR_PLACES = [
     coords: { x: 609, y: 149, z: -1509 },
     description: "Trading hub in Perm Town",
     category: "Trading",
-  },
-  {
-    id: "default-baby-yoda",
-    name: "Baby Yoda",
-    coords: { x: 0, y: 0, z: 0 },
-    description: "Baby Yoda landmark",
-    category: "Landmark",
   },
   {
     id: "default-ethereum-monument",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set Waypoint available on Article, Discover, and Local pages; buttons added with error handling and disabled states when unavailable.
  * Discover now uses on-chain data with category/author/search filters, date sorting, coordinates display, and distance from current position.
  * Local page respects current player position with quick reset.
  * Article footers show coordinates.
  * ArticleCard images now lazy-load with a shimmer placeholder and fade-in.

* **Chores**
  * Updated Popular Places: renamed “RaidGuild,” removed “Arena Eternal” and “Baby Yoda.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->