### PR TITLE
feat: add front page submission CTA

### DIFF
--- a/packages/app/src/components/editor/ArticleWizardStep1.tsx
+++ b/packages/app/src/components/editor/ArticleWizardStep1.tsx
@@ -1,5 +1,6 @@
 import { Jimp } from "jimp";
 
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { uriToHttp } from "@/utils/helpers";
 
@@ -71,17 +72,32 @@ export default function ArticleWizardStep1({
 
   return (
     <div className="space-y-3">
+      <div>
+        <label
+          className={cn("font-accent", "text-[10px]")}
+          htmlFor="article-title-input"
+        >
+          Article Title
+        </label>
+        <Input
+          id="article-title-input"
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="My Amazing Article Title"
+          value={title}
+        />
+      </div>
       {API_BASE && (
-        <>
+        <div>
+          <label
+            className={cn("font-accent", "text-[10px]")}
+            htmlFor="article-cover-image-input"
+          >
+            Cover Image
+          </label>
           <input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="Title"
-            className="w-full text-xl font-semibold border-none outline-none bg-transparent"
-          />
-          <input
+            id="article-cover-image-input"
             accept="image/png, image/jpeg, image/jpg"
-            className="bg-panel border border-neutral-200 px-2 py-1 rounded text-sm w-full"
+            className="text-sm w-full"
             onChange={(e) => {
               const file = e.target.files?.[0];
               if (file) {
@@ -97,7 +113,7 @@ export default function ArticleWizardStep1({
             }}
             type="file"
           />
-        </>
+        </div>
       )}
 
       {coverImage && (
@@ -115,87 +131,103 @@ export default function ArticleWizardStep1({
         className="w-full text-sm border border-neutral-200 rounded px-2 py-1 bg-panel"
       />
 
-      <select
-        id="article-category-select"
-        aria-label="Type"
-        className={cn(
-          "border-input bg-transparent border border-neutral-900",
-          "h-9 w-full rounded-md px-3 py-1 text-base shadow-xs",
-          "transition-[color,box-shadow] outline-none",
-          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-          "md:text-sm"
-        )}
-        onChange={(e) => setCategory(e.target.value)}
-        value={category}
-      >
-        {articleCategories.map((c) => (
-          <option key={c} value={c}>
-            {c}
-          </option>
-        ))}
-      </select>
-
-      {/* Markdown toolbar */}
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={() => applyFormatting("h1")}
-          className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+      <div>
+        <label
+          className={cn("font-accent", "text-[10px]")}
+          htmlFor="article-category-select"
         >
-          H1
-        </button>
-        <button
-          type="button"
-          onClick={() => applyFormatting("h2")}
-          className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+          Category
+        </label>
+        <select
+          id="article-category-select"
+          aria-label="Type"
+          className={cn(
+            "border-input bg-transparent border border-neutral-900",
+            "h-9 w-full rounded-md px-3 py-1 text-base shadow-xs",
+            "transition-[color,box-shadow] outline-none",
+            "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+            "md:text-sm"
+          )}
+          onChange={(e) => setCategory(e.target.value)}
+          value={category}
         >
-          H2
-        </button>
-        <button
-          type="button"
-          onClick={() => applyFormatting("h3")}
-          className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
-        >
-          H3
-        </button>
-        <button
-          type="button"
-          onClick={() => applyFormatting("bold")}
-          className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
-        >
-          Bold
-        </button>
-        <button
-          type="button"
-          onClick={() => applyFormatting("italic")}
-          className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
-        >
-          Italic
-        </button>
+          {articleCategories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
       </div>
 
-      <textarea
-        id="article-content-textarea"
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        placeholder="Write your article in markdown..."
-        className="w-full h-80 p-2 text-sm border border-neutral-200 rounded bg-transparent"
-      />
+      <div className="space-y-2">
+        <label
+          className={cn("font-accent", "text-[10px]")}
+          htmlFor="article-content-textarea"
+        >
+          Content
+        </label>
+        {/* Markdown toolbar */}
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => applyFormatting("h1")}
+            className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+          >
+            H1
+          </button>
+          <button
+            type="button"
+            onClick={() => applyFormatting("h2")}
+            className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+          >
+            H2
+          </button>
+          <button
+            type="button"
+            onClick={() => applyFormatting("h3")}
+            className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+          >
+            H3
+          </button>
+          <button
+            type="button"
+            onClick={() => applyFormatting("bold")}
+            className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+          >
+            Bold
+          </button>
+          <button
+            type="button"
+            onClick={() => applyFormatting("italic")}
+            className="px-2 py-1 text-xs bg-neutral-100 rounded hover:bg-neutral-200"
+          >
+            Italic
+          </button>
+        </div>
 
-      <div className="flex gap-2">
-        <button
-          onClick={handleSaveDraft}
-          className="px-3 py-1.5 text-sm bg-neutral-100 rounded hover:bg-neutral-200"
-        >
-          {justSaved ? "Saved" : "Save Draft"}
-        </button>
-        <button
-          disabled={!canContinueFrom1}
-          onClick={() => onContinue?.()}
-          className="px-3 py-1.5 text-sm bg-white text-text-primary border border-neutral-900 rounded hover:bg-neutral-100 disabled:opacity-50"
-        >
-          Continue
-        </button>
+        <textarea
+          id="article-content-textarea"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write your article in markdown..."
+          className="w-full h-80 p-2 text-sm border border-neutral-200 rounded bg-transparent"
+        />
+
+        <div className="flex gap-2">
+          <button
+            onClick={handleSaveDraft}
+            className="px-3 py-1.5 text-sm bg-neutral-100 rounded hover:bg-neutral-200"
+          >
+            {justSaved ? "Saved" : "Save Draft"}
+          </button>
+          <button
+            disabled={!canContinueFrom1}
+            onClick={() => onContinue?.()}
+            className="px-3 py-1.5 text-sm bg-white text-text-primary border border-neutral-900 rounded hover:bg-neutral-100 disabled:opacity-50"
+          >
+            Continue
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/app/src/pages/EditorRoomPage.tsx
+++ b/packages/app/src/pages/EditorRoomPage.tsx
@@ -4,8 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useDustClient } from "@/common/useDustClient";
 import { ArticleWizard } from "@/components/editor/ArticleWizard";
-import { Button } from "@/components/ui/button";
 import PublishedList from "@/components/editor/PublishedList";
+import { Button } from "@/components/ui/button";
 import { stash, tables } from "@/mud/stash";
 
 export const EditorRoomPage = () => {
@@ -348,7 +348,7 @@ export const EditorRoomPage = () => {
             onClick={() => setOpen(false)}
           />
           <div className="relative w-full max-w-4xl mx-auto">
-            <div className="bg-panel border border-neutral-200 dark:border-neutral-800 rounded-lg shadow-lg overflow-hidden">
+            <div className="bg-panel border border-neutral-200 dark:border-neutral-800 rounded-lg shadow-lg max-h-[80vh] overflow-scroll">
               <ArticleWizard
                 draftId={wizardDraftId}
                 articleId={wizardArticleId}

--- a/packages/app/src/pages/FrontPage.tsx
+++ b/packages/app/src/pages/FrontPage.tsx
@@ -1,10 +1,10 @@
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 
-import { type Article, ArticleCard } from "@/components/ArticleCard";
+// import { type Article, ArticleCard } from "@/components/ArticleCard";
 import { PixelDivider } from "@/components/PixelDivider";
-import { weeklyCurated } from "@/dummy-data";
+// import { weeklyCurated } from "@/dummy-data";
 import { cn } from "@/lib/utils";
-import { ARTICLE_PAGE_PATH } from "@/Routes";
+// import { ARTICLE_PAGE_PATH } from "@/Routes";
 
 export const FrontPage = () => {
   return (
@@ -12,7 +12,7 @@ export const FrontPage = () => {
       <div className="grid gap-4 sm:gap-6">
         <TopBanner />
         <PixelDivider />
-        <div className="lg:grid-cols-3 gap-6 grid grid-cols-1">
+        {/* <div className="lg:grid-cols-3 gap-6 grid grid-cols-1">
           {weeklyCurated[0] && <LeadStory article={weeklyCurated[0]} />}
           <div className="lg:col-span-2 gap-6 grid">
             <div className="gap-6 grid md:grid-cols-2">
@@ -23,7 +23,7 @@ export const FrontPage = () => {
               ))}
             </div>
           </div>
-        </div>
+        </div> */}
       </div>
     </section>
   );
@@ -38,52 +38,53 @@ const TopBanner = () => {
           "leading-tight lg:text-6xl sm:text-5xl text-center text-4xl"
         )}
       >
-        City Hall Promises Iron Golem
+        The Daily Dust Launches!
       </h1>
       <p className="max-w-3xl mx-auto text-center text-neutral-800">
-        Alder-blocks approved funding to deploy a dedicated squad.
+        Submit your articles through the Editor Room. The paper will display its
+        first front page of top stories on <strong>Sunday, August 17th</strong>.
       </p>
     </div>
   );
 };
 
-const LeadStory = ({ article }: { article: Article }) => {
-  return (
-    <div className="border border-neutral-900 bg-neutral-50">
-      <img
-        alt={article.title}
-        className="grayscale object-cover w-full"
-        decoding="async"
-        fetchPriority="high"
-        height={800}
-        loading="eager"
-        src={article.image}
-        width={1200}
-      />
-      <div className="p-4">
-        <div
-          className={cn(
-            "font-accent",
-            "mb-1 text-neutral-700 text-[10px] tracking-widest uppercase"
-          )}
-        >
-          Lead Story
-        </div>
-        <h2 className={cn("font-heading", "text-2xl leading-snug")}>
-          <Link
-            className="hover:underline cursor-pointer"
-            to={`${ARTICLE_PAGE_PATH}${encodeURIComponent(article.id)}`}
-          >
-            {article.title}
-          </Link>
-        </h2>
-        <p className={"mt-2 text-[15px] leading-relaxed"}>{article.excerpt}</p>
-        <div className={cn("font-accent", "mt-1 text-[10px] text-neutral-700")}>
-          {"Near: "}
-          {article.city ? `${article.city} • ` : ""}x:{article.coords.x} y:
-          {article.coords.y} z:{article.coords.z}
-        </div>
-      </div>
-    </div>
-  );
-};
+// const LeadStory = ({ article }: { article: Article }) => {
+//   return (
+//     <div className="border border-neutral-900 bg-neutral-50">
+//       <img
+//         alt={article.title}
+//         className="grayscale object-cover w-full"
+//         decoding="async"
+//         fetchPriority="high"
+//         height={800}
+//         loading="eager"
+//         src={article.image}
+//         width={1200}
+//       />
+//       <div className="p-4">
+//         <div
+//           className={cn(
+//             "font-accent",
+//             "mb-1 text-neutral-700 text-[10px] tracking-widest uppercase"
+//           )}
+//         >
+//           Lead Story
+//         </div>
+//         <h2 className={cn("font-heading", "text-2xl leading-snug")}>
+//           <Link
+//             className="hover:underline cursor-pointer"
+//             to={`${ARTICLE_PAGE_PATH}${encodeURIComponent(article.id)}`}
+//           >
+//             {article.title}
+//           </Link>
+//         </h2>
+//         <p className={"mt-2 text-[15px] leading-relaxed"}>{article.excerpt}</p>
+//         <div className={cn("font-accent", "mt-1 text-[10px] text-neutral-700")}>
+//           {"Near: "}
+//           {article.city ? `${article.city} • ` : ""}x:{article.coords.x} y:
+//           {article.coords.y} z:{article.coords.z}
+//         </div>
+//       </div>
+//     </div>
+//   );
+// };

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -4,9 +4,7 @@ export default defineWorld({
   codegen: {
     generateSystemLibraries: true,
   },
-  // Replace this with a unique namespace (<= 14 chars)
-  // rg: raidguild dd: dailydust deployer: ab564f
-  namespace: "rg_dd_0003",
+  namespace: "thedailydust",
   systems: {
     AdminSystem: {
       openAccess: false,

--- a/packages/contracts/out/IWorld.sol/IWorld.abi.json
+++ b/packages/contracts/out/IWorld.sol/IWorld.abi.json
@@ -912,102 +912,6 @@
   },
   {
     "type": "function",
-    "name": "rg_dd_0003___msgSender",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "rg_dd_0003___msgValue",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "rg_dd_0003__onAttachProgram",
-    "inputs": [
-      {
-        "name": "ctx",
-        "type": "tuple",
-        "internalType": "struct HookContext",
-        "components": [
-          {
-            "name": "caller",
-            "type": "bytes32",
-            "internalType": "EntityId"
-          },
-          {
-            "name": "target",
-            "type": "bytes32",
-            "internalType": "EntityId"
-          },
-          {
-            "name": "revertOnFailure",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "extraData",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "rg_dd_0003__onDetachProgram",
-    "inputs": [
-      {
-        "name": "ctx",
-        "type": "tuple",
-        "internalType": "struct HookContext",
-        "components": [
-          {
-            "name": "caller",
-            "type": "bytes32",
-            "internalType": "EntityId"
-          },
-          {
-            "name": "target",
-            "type": "bytes32",
-            "internalType": "EntityId"
-          },
-          {
-            "name": "revertOnFailure",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "extraData",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "setDynamicField",
     "inputs": [
       {
@@ -1239,6 +1143,102 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "thedailydust___msgSender",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "thedailydust___msgValue",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "thedailydust__onAttachProgram",
+    "inputs": [
+      {
+        "name": "ctx",
+        "type": "tuple",
+        "internalType": "struct HookContext",
+        "components": [
+          {
+            "name": "caller",
+            "type": "bytes32",
+            "internalType": "EntityId"
+          },
+          {
+            "name": "target",
+            "type": "bytes32",
+            "internalType": "EntityId"
+          },
+          {
+            "name": "revertOnFailure",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "extraData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "thedailydust__onDetachProgram",
+    "inputs": [
+      {
+        "name": "ctx",
+        "type": "tuple",
+        "internalType": "struct HookContext",
+        "components": [
+          {
+            "name": "caller",
+            "type": "bytes32",
+            "internalType": "EntityId"
+          },
+          {
+            "name": "target",
+            "type": "bytes32",
+            "internalType": "EntityId"
+          },
+          {
+            "name": "revertOnFailure",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "extraData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",

--- a/packages/contracts/src/codegen/systems/AdminSystemLib.sol
+++ b/packages/contracts/src/codegen/systems/AdminSystemLib.sol
@@ -14,9 +14,9 @@ import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 type AdminSystemType is bytes32;
 
-// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "rg_dd_0003", name: "AdminSystem" }))
+// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "thedailydust", name: "AdminSystem" }))
 AdminSystemType constant adminSystem = AdminSystemType.wrap(
-  0x737972675f64645f303030330000000041646d696e53797374656d0000000000
+  0x73797468656461696c7964757374000041646d696e53797374656d0000000000
 );
 
 struct CallWrapper {

--- a/packages/contracts/src/codegen/systems/ArticleSystemLib.sol
+++ b/packages/contracts/src/codegen/systems/ArticleSystemLib.sol
@@ -14,9 +14,9 @@ import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 type ArticleSystemType is bytes32;
 
-// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "rg_dd_0003", name: "ArticleSystem" }))
+// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "thedailydust", name: "ArticleSystem" }))
 ArticleSystemType constant articleSystem = ArticleSystemType.wrap(
-  0x737972675f64645f303030330000000041727469636c6553797374656d000000
+  0x73797468656461696c7964757374000041727469636c6553797374656d000000
 );
 
 struct CallWrapper {

--- a/packages/contracts/src/codegen/systems/BaseProgramLib.sol
+++ b/packages/contracts/src/codegen/systems/BaseProgramLib.sol
@@ -15,9 +15,9 @@ import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 type BaseProgramType is bytes32;
 
-// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "rg_dd_0003", name: "BaseProgram" }))
+// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "thedailydust", name: "BaseProgram" }))
 BaseProgramType constant baseProgram = BaseProgramType.wrap(
-  0x737972675f64645f30303033000000004261736550726f6772616d0000000000
+  0x73797468656461696c796475737400004261736550726f6772616d0000000000
 );
 
 struct CallWrapper {

--- a/packages/contracts/src/codegen/systems/CollectionSystemLib.sol
+++ b/packages/contracts/src/codegen/systems/CollectionSystemLib.sol
@@ -14,9 +14,9 @@ import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 type CollectionSystemType is bytes32;
 
-// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "rg_dd_0003", name: "CollectionSystem" }))
+// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "thedailydust", name: "CollectionSystem" }))
 CollectionSystemType constant collectionSystem = CollectionSystemType.wrap(
-  0x737972675f64645f3030303300000000436f6c6c656374696f6e53797374656d
+  0x73797468656461696c79647573740000436f6c6c656374696f6e53797374656d
 );
 
 struct CallWrapper {

--- a/packages/contracts/src/codegen/systems/NoteSystemLib.sol
+++ b/packages/contracts/src/codegen/systems/NoteSystemLib.sol
@@ -14,9 +14,9 @@ import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 type NoteSystemType is bytes32;
 
-// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "rg_dd_0003", name: "NoteSystem" }))
+// equivalent to WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: "thedailydust", name: "NoteSystem" }))
 NoteSystemType constant noteSystem = NoteSystemType.wrap(
-  0x737972675f64645f30303033000000004e6f746553797374656d000000000000
+  0x73797468656461696c796475737400004e6f746553797374656d000000000000
 );
 
 struct CallWrapper {

--- a/packages/contracts/src/codegen/tables/ArticleCategories.sol
+++ b/packages/contracts/src/codegen/tables/ArticleCategories.sol
@@ -17,8 +17,8 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
 library ArticleCategories {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "ArticleCategorie", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f303030330000000041727469636c6543617465676f726965);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "ArticleCategorie", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c7964757374000041727469636c6543617465676f726965);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0000000100000000000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/Category.sol
+++ b/packages/contracts/src/codegen/tables/Category.sol
@@ -17,8 +17,8 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
 library Category {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "Category", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f303030330000000043617465676f72790000000000000000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "Category", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c7964757374000043617465676f72790000000000000000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0000000100000000000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/Collection.sol
+++ b/packages/contracts/src/codegen/tables/Collection.sol
@@ -26,8 +26,8 @@ struct CollectionData {
 }
 
 library Collection {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "Collection", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f3030303300000000436f6c6c656374696f6e000000000000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "Collection", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c79647573740000436f6c6c656374696f6e000000000000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0024030308140800000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/CollectionPost.sol
+++ b/packages/contracts/src/codegen/tables/CollectionPost.sol
@@ -17,8 +17,8 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
 library CollectionPost {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "CollectionPost", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f3030303300000000436f6c6c656374696f6e506f73740000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "CollectionPost", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c79647573740000436f6c6c656374696f6e506f73740000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0002010002000000000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/IsArticle.sol
+++ b/packages/contracts/src/codegen/tables/IsArticle.sol
@@ -17,8 +17,8 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
 library IsArticle {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "IsArticle", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f3030303300000000497341727469636c6500000000000000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "IsArticle", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c79647573740000497341727469636c6500000000000000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0001010001000000000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/IsNote.sol
+++ b/packages/contracts/src/codegen/tables/IsNote.sol
@@ -17,8 +17,8 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
 library IsNote {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "IsNote", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f303030330000000049734e6f746500000000000000000000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "IsNote", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c7964757374000049734e6f746500000000000000000000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0001010001000000000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/NoteCategories.sol
+++ b/packages/contracts/src/codegen/tables/NoteCategories.sol
@@ -17,8 +17,8 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
 library NoteCategories {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "NoteCategories", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f30303033000000004e6f746543617465676f726965730000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "NoteCategories", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c796475737400004e6f746543617465676f726965730000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0000000100000000000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/Post.sol
+++ b/packages/contracts/src/codegen/tables/Post.sol
@@ -27,8 +27,8 @@ struct PostData {
 }
 
 library Post {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "Post", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f3030303300000000506f7374000000000000000000000000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "Post", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c79647573740000506f7374000000000000000000000000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0024030408140800000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/tables/PostAnchor.sol
+++ b/packages/contracts/src/codegen/tables/PostAnchor.sol
@@ -24,8 +24,8 @@ struct PostAnchorData {
 }
 
 library PostAnchor {
-  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "rg_dd_0003", name: "PostAnchor", typeId: RESOURCE_TABLE });`
-  ResourceId constant _tableId = ResourceId.wrap(0x746272675f64645f3030303300000000506f7374416e63686f72000000000000);
+  // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "thedailydust", name: "PostAnchor", typeId: RESOURCE_TABLE });`
+  ResourceId constant _tableId = ResourceId.wrap(0x74627468656461696c79647573740000506f7374416e63686f72000000000000);
 
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x002c040020040404000000000000000000000000000000000000000000000000);

--- a/packages/contracts/src/codegen/world/IBaseProgram.sol
+++ b/packages/contracts/src/codegen/world/IBaseProgram.sol
@@ -11,11 +11,11 @@ import { HookContext } from "@dust/world/src/ProgramHooks.sol";
  * @dev This interface is automatically generated from the corresponding system contract. Do not edit manually.
  */
 interface IBaseProgram {
-  function rg_dd_0003__onAttachProgram(HookContext calldata ctx) external;
+  function thedailydust__onAttachProgram(HookContext calldata ctx) external;
 
-  function rg_dd_0003__onDetachProgram(HookContext calldata ctx) external;
+  function thedailydust__onDetachProgram(HookContext calldata ctx) external;
 
-  function rg_dd_0003___msgSender() external view returns (address);
+  function thedailydust___msgSender() external view returns (address);
 
-  function rg_dd_0003___msgValue() external view returns (uint256);
+  function thedailydust___msgValue() external view returns (uint256);
 }


### PR DESCRIPTION
This pull request updates both the frontend and smart contract layers to improve the article editor UX and to standardize the contract namespace across the codebase. The frontend changes enhance the article submission workflow with better labeling and structure, while the contract changes update the namespace from a generic identifier to a project-specific one, ensuring consistency and clarity.

**Frontend improvements to article editor:**

- Added accessible labels and improved structure to the article wizard step, including labeled fields for title, cover image, category, and content, and switched to using the `Input` component for better UI consistency (`ArticleWizardStep1.tsx`). [[1]](diffhunk://#diff-0bb7265977c580c4957706c4cdca98fd719101e7c5cf83c3516ea087fca33c1aR3) [[2]](diffhunk://#diff-0bb7265977c580c4957706c4cdca98fd719101e7c5cf83c3516ea087fca33c1aL74-R100) [[3]](diffhunk://#diff-0bb7265977c580c4957706c4cdca98fd719101e7c5cf83c3516ea087fca33c1aL100-R116) [[4]](diffhunk://#diff-0bb7265977c580c4957706c4cdca98fd719101e7c5cf83c3516ea087fca33c1aR134-R140) [[5]](diffhunk://#diff-0bb7265977c580c4957706c4cdca98fd719101e7c5cf83c3516ea087fca33c1aR160-R168) [[6]](diffhunk://#diff-0bb7265977c580c4957706c4cdca98fd719101e7c5cf83c3516ea087fca33c1aR232)
- Limited the article wizard modal's height and enabled scrolling to improve usability on smaller screens (`EditorRoomPage.tsx`).

**Frontend changes to front page:**

- Updated the front page banner with new launch messaging and disabled the display of curated articles and lead story components, likely as a temporary measure during launch (`FrontPage.tsx`). [[1]](diffhunk://#diff-23ad7929f420d43831025df171b59aef8e684f8baac8e14a8dd27d6f919e9073L1-R15) [[2]](diffhunk://#diff-23ad7929f420d43831025df171b59aef8e684f8baac8e14a8dd27d6f919e9073L26-R26) [[3]](diffhunk://#diff-23ad7929f420d43831025df171b59aef8e684f8baac8e14a8dd27d6f919e9073L41-R90)

**Smart contract namespace standardization:**

- Changed the contract namespace from `"rg_dd_0003"` to `"thedailydust"` throughout the MUD config and all generated system and table libraries, updating all associated resource IDs for consistency and clarity (`mud.config.ts`, all `SystemLib.sol` and table `.sol` files). [[1]](diffhunk://#diff-18964a0c75202055d59f50b683137b1f0cd5ebbfc4af97ef5f1850f4f5154ce8L7-R7) [[2]](diffhunk://#diff-e57249aa421b875af4c7a523d1bbce3995ee2e47ba58e2a5550aee4085add79dL17-R19) [[3]](diffhunk://#diff-758033a9e41c0268a1fa5a0ea6e3f3b1ba941666260e569877af4c5e492c56daL17-R19) [[4]](diffhunk://#diff-3c214a120c7094351c8013f79c428fa88c2ac89fc90360e3309d8edc4687d9f1L18-R20) [[5]](diffhunk://#diff-ba8e9133f2990de44dcd2bb0a671e6d022ea95886cdafc979a5261dc060bb2e9L17-R19) [[6]](diffhunk://#diff-f69bb767cf247972667531faa917b87b86fcf5af34e0cd90a2bd9df7d25cc7bcL17-R19) [[7]](diffhunk://#diff-b6066c5893e0963debba87171990e199388e73fd9abbf16c4f4dfcdc5272016fL20-R21) [[8]](diffhunk://#diff-cc12d3098854d317692a22499fdfd20fffbb90a89f9e6c483a1f04de4970f627L29-R30) [[9]](diffhunk://#diff-8b8ebc8fe91c1994cab90c0abc46387ed39d903506663e509490df0066f9875cL20-R21) [[10]](diffhunk://#diff-ccfb513baad2cfcca064fcb46481cce43063bf09b35189158bceb740c879593bL20-R21) [[11]](diffhunk://#diff-456ae081df7a149084f0b0a0abcf33343710f910ae1af47b668e2a4a2fac8f93L20-R21) [[12]](diffhunk://#diff-59c8effa0ea923c50ffa7a0b24766dd2c5ecc4801c5ed6164a3b7ba40f92e225L20-R21)