### PR TITLE
change week on front page

### DIFF
--- a/packages/app/src/components/Masthead.tsx
+++ b/packages/app/src/components/Masthead.tsx
@@ -54,7 +54,7 @@ export const Masthead = () => {
                   "hidden sm:block text-[10px] text-neutral-700"
                 )}
               >
-                {"Est. 2025 • Week 32"}
+                {"Est. 2025 • Week 1"}
               </div>
             </div>
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Masthead copy to display “Est. 2025 • Week 1” instead of “Est. 2025 • Week 32.”
  - Change is purely textual; no adjustments to layout, styling, or component behavior.
  - No impact on navigation, performance, or interactions; users will only notice the updated week indicator.
  - Component interface remains unchanged, ensuring consistent experience across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->