### PR TITLE
fix: make sure cover images use uri converter

### DIFF
--- a/packages/app/src/components/ArticleCard.tsx
+++ b/packages/app/src/components/ArticleCard.tsx
@@ -1,8 +1,9 @@
-import { Link } from "react-router-dom";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 import { cn } from "@/lib/utils";
 import { ARTICLE_PAGE_PATH } from "@/Routes";
+import { uriToHttp } from "@/utils/helpers";
 
 export type Article = {
   id: string;
@@ -50,15 +51,15 @@ export const ArticleCard = ({
             className="absolute inset-0 bg-neutral-200"
             style={{
               backgroundImage:
-                'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0) 100%)',
-              backgroundSize: '200% 100%',
-              animation: 'shimmer 1.2s linear infinite',
+                "linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0) 100%)",
+              backgroundSize: "200% 100%",
+              animation: "shimmer 1.2s linear infinite",
             }}
           />
         )}
         <img
           alt={article.title}
-          src={article.image}
+          src={uriToHttp(article.image)[0]}
           loading="lazy"
           onLoad={() => setImgLoaded(true)}
           className={`aspect-video grayscale object-cover w-full transition-opacity duration-500 ${

--- a/packages/app/src/components/Masthead.tsx
+++ b/packages/app/src/components/Masthead.tsx
@@ -1,7 +1,8 @@
 import { Newspaper, Pin } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { useEffect, useState, useCallback } from "react";
 
+import { PinnedApp } from "@/components/PinnedApp";
 import { cn } from "@/lib/utils";
 import {
   BACK_PAGE_PATH,
@@ -10,7 +11,6 @@ import {
   FRONT_PAGE_PATH,
   LOCAL_PAGE_PATH,
 } from "@/Routes";
-import { PinnedApp } from "@/components/PinnedApp";
 
 const nav = [
   { href: FRONT_PAGE_PATH, label: "Front Page" },
@@ -40,13 +40,17 @@ export const Masthead = () => {
       try {
         localStorage.setItem("pinnedApp", next ? "true" : "false");
       } catch (e) {}
-      try { console.log && console.log('[Masthead] togglePin', { prev, next }); } catch (e) {}
+      try {
+        console.log && console.log("[Masthead] togglePin", { prev, next });
+      } catch (e) {}
       return next;
     });
   }, []);
 
   useEffect(() => {
-    try { console.log && console.log('[Masthead] open changed', { open }); } catch (e) {}
+    try {
+      console.log && console.log("[Masthead] open changed", { open });
+    } catch (e) {}
   }, [open]);
 
   const handleClose = useCallback(() => setOpen(false), []);
@@ -95,7 +99,7 @@ export const Masthead = () => {
                 )}
               >
                 <div className="flex items-center gap-2">
-                  {"Est. 2025 • Week 32"}
+                  {"Est. 2025 • Week 0"}
                   <button
                     title={pinned ? "Unpin app" : "Pin app"}
                     onClick={() => togglePin()}

--- a/packages/app/src/components/editor/ArticleWizardStep2.tsx
+++ b/packages/app/src/components/editor/ArticleWizardStep2.tsx
@@ -1,4 +1,5 @@
 import { useENS } from "@/common/useENS";
+import { uriToHttp } from "@/utils/helpers";
 
 interface Props {
   coverImage: string;
@@ -60,7 +61,7 @@ export default function ArticleWizardStep2({
           <img
             alt={title}
             className="grayscale object-cover w-full"
-            src={coverImage}
+            src={uriToHttp(coverImage)[0]}
           />
         </div>
       ) : null}


### PR DESCRIPTION
This pull request focuses on improving image URL handling and making minor code style and content adjustments across several components. The most significant change is the consistent use of the `uriToHttp` utility to ensure image sources are properly formatted, which enhances reliability when displaying images. Additionally, there are some minor cleanups and a content update.

**Image handling improvements:**

* Updated `ArticleCard` and `ArticleWizardStep2` components to use `uriToHttp` for image URLs, ensuring images are loaded from valid HTTP sources. [[1]](diffhunk://#diff-f080414ad504459441620a73eb88744c7ac558a2e198493ba38e7590d8381afeL1-R6) [[2]](diffhunk://#diff-f080414ad504459441620a73eb88744c7ac558a2e198493ba38e7590d8381afeL53-R62) [[3]](diffhunk://#diff-a70cfbd509a08ded64ce53368db126781dd4b1a6ffda46a260ab746cb95388b1R2) [[4]](diffhunk://#diff-a70cfbd509a08ded64ce53368db126781dd4b1a6ffda46a260ab746cb95388b1L63-R64)

**Code cleanup and style consistency:**

* Standardized import order and formatting in `Masthead.tsx` for better readability and maintainability. [[1]](diffhunk://#diff-12ca3d5352126d9dcb88a6a2a01d64604ca9a26e4559f74662398793910eb508R2-R5) [[2]](diffhunk://#diff-12ca3d5352126d9dcb88a6a2a01d64604ca9a26e4559f74662398793910eb508L13)
* Reformatted logging statements in `Masthead` for consistency and readability.

**Content update:**

* Changed the displayed week in the `Masthead` component from "Week 32" to "Week 0".