### PR TITLE
fix: make sure refresh on routes in Vercel works

### DIFF
--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
This pull request adds a `vercel.json` configuration file to the project. The new file sets up a rewrite rule to ensure all incoming requests are routed to the root path, which is commonly used for single-page applications.

Deployment configuration:

* Added `vercel.json` with a rewrite rule that routes all paths to `/`, supporting client-side routing for the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminates 404 errors when accessing deep links or refreshing pages in the deployed app on Vercel.
* **Chores**
  * Added hosting configuration to route all paths to the root, ensuring proper single-page app navigation and consistent URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->