### PR TITLE
fix: make sure new article wizard uses article categories

### DIFF
--- a/packages/app/src/components/editor/ArticleWizard.tsx
+++ b/packages/app/src/components/editor/ArticleWizard.tsx
@@ -228,7 +228,7 @@ export const ArticleWizard: React.FC<Props> = ({
   useEffect(() => {
     const categories = (getRecord({
       stash,
-      table: tables.NoteCategories,
+      table: tables.ArticleCategories,
       key: {},
     })
       ?.value?.map((c) => {


### PR DESCRIPTION
This pull request makes a small change to the `ArticleWizard` component to ensure it retrieves article categories instead of note categories. This improves data accuracy and consistency when displaying categories in the wizard.