### PR TITLE
refactor: remove duplicate code

### DIFF
--- a/packages/app/src/common/useCategories.tsx
+++ b/packages/app/src/common/useCategories.tsx
@@ -1,0 +1,47 @@
+import { getRecord } from "@latticexyz/stash/internal";
+import { useEffect, useState } from "react";
+
+import { stash, tables } from "@/mud/stash";
+
+export const useCategories = () => {
+  const [articleCategories, setArticleCategories] = useState<string[]>([]);
+  const [noteCategories, setNoteCategories] = useState<string[]>([]);
+
+  useEffect(() => {
+    const _articleCategories = (getRecord({
+      stash,
+      table: tables.NoteCategories,
+      key: {},
+    })
+      ?.value?.map((c) => {
+        return getRecord({
+          stash,
+          table: tables.Category,
+          key: { id: c },
+        })?.value;
+      })
+      .filter((c): c is string => !!c) ?? []) as string[];
+
+    const _noteCategories = (getRecord({
+      stash,
+      table: tables.NoteCategories,
+      key: {},
+    })
+      ?.value?.map((c) => {
+        return getRecord({
+          stash,
+          table: tables.Category,
+          key: { id: c },
+        })?.value;
+      })
+      .filter((c): c is string => !!c) ?? []) as string[];
+
+    setArticleCategories(_articleCategories);
+    setNoteCategories(_noteCategories);
+  }, []);
+
+  return {
+    articleCategories,
+    noteCategories,
+  };
+};

--- a/packages/app/src/common/useCategories.tsx
+++ b/packages/app/src/common/useCategories.tsx
@@ -10,7 +10,7 @@ export const useCategories = () => {
   useEffect(() => {
     const _articleCategories = (getRecord({
       stash,
-      table: tables.NoteCategories,
+      table: tables.ArticleCategories,
       key: {},
     })
       ?.value?.map((c) => {

--- a/packages/app/src/common/usePlayerName.tsx
+++ b/packages/app/src/common/usePlayerName.tsx
@@ -1,0 +1,27 @@
+import { getRecord } from "@latticexyz/stash/internal";
+import { useMemo } from "react";
+import { hexToString, isAddress } from "viem";
+
+import { stash, tables } from "@/mud/stash";
+
+export const usePlayerName = (playerAddress: string | undefined) => {
+  const playerName = useMemo(() => {
+    if (!playerAddress) return "Anonymous";
+    if (isAddress(playerAddress) === false) return "Anonymous";
+
+    const ownerUsername = getRecord({
+      stash,
+      table: tables.PlayerName,
+      key: { player: playerAddress as `0x${string}` },
+    })?.name;
+
+    if (ownerUsername) {
+      return hexToString(ownerUsername).replace(/\0+$/, "");
+    }
+    return "Anonymous";
+  }, [playerAddress]);
+
+  return {
+    playerName,
+  };
+};

--- a/packages/app/src/common/usePosts.tsx
+++ b/packages/app/src/common/usePosts.tsx
@@ -60,6 +60,7 @@ export const usePosts = (): {
         distance: null,
         excerpt,
         owner: r.owner,
+        rawContent: typeof r.content === "string" ? r.content : "",
         title: r.title,
         type: isArticle ? "article" : "note",
         updatedAt: r.updatedAt,

--- a/packages/app/src/common/usePosts.tsx
+++ b/packages/app/src/common/usePosts.tsx
@@ -1,0 +1,88 @@
+import { getRecord } from "@latticexyz/stash/internal";
+import { useRecords } from "@latticexyz/stash/react";
+import { useMemo } from "react";
+
+import { stash, tables } from "@/mud/stash";
+import { getDistance } from "@/utils/helpers";
+import type { Post } from "@/utils/types";
+
+import { usePlayerPositionQuery } from "./usePlayerPositionQuery";
+
+export const usePosts = (): {
+  articles: Post[];
+  notes: Post[];
+  posts: Post[];
+} => {
+  const { data: playerPosition } = usePlayerPositionQuery();
+
+  const posts = useRecords({
+    stash,
+    table: tables.Post,
+  })
+    .map((r): Post => {
+      const isArticle =
+        getRecord({
+          stash,
+          table: tables.IsArticle,
+          key: { id: r.id as `0x${string}` },
+        })?.value ?? false;
+      let category: null | string = null;
+
+      const anchor =
+        getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
+        null;
+
+      const excerpt =
+        typeof r.content === "string"
+          ? (r.content.split("\n\n")[0] || r.content).slice(0, 240)
+          : "";
+
+      if (r.categories[0]) {
+        category =
+          getRecord({
+            stash,
+            table: tables.Category,
+            key: { id: r.categories[0] as `0x${string}` },
+          })?.value ?? null;
+      }
+
+      return {
+        id: r.id,
+        categories: category ? [category] : [],
+        content: (typeof r.content === "string"
+          ? r.content.split("\n\n")
+          : []) as string[],
+        coords: anchor
+          ? { x: anchor.coordX, y: anchor.coordY, z: anchor.coordZ }
+          : null,
+        createdAt: r.createdAt,
+        coverImage: r.coverImage || "/assets/placeholder-notext.png",
+        distance: null,
+        excerpt,
+        owner: r.owner,
+        title: r.title,
+        type: isArticle ? "article" : "note",
+        updatedAt: r.updatedAt,
+      };
+    })
+    .map((p) => ({
+      ...p,
+      distance:
+        p.coords && playerPosition
+          ? getDistance(playerPosition, p.coords)
+          : null,
+    }))
+    .sort((a, b) => Number(b.createdAt - a.createdAt));
+
+  const articles = useMemo(
+    () => posts.filter((p) => p.type === "article"),
+    [posts]
+  );
+  const notes = useMemo(() => posts.filter((p) => p.type === "note"), [posts]);
+
+  return {
+    articles,
+    notes,
+    posts,
+  };
+};

--- a/packages/app/src/common/useWaypoint.tsx
+++ b/packages/app/src/common/useWaypoint.tsx
@@ -1,0 +1,39 @@
+import { encodeBlock } from "@dust/world/internal";
+import { toast } from "sonner";
+
+import type { Post } from "@/utils/types";
+
+import { useDustClient } from "./useDustClient";
+
+export const useWaypoint = () => {
+  const { data: dustClient } = useDustClient();
+
+  const onSetWaypoint = async (post: Post) => {
+    try {
+      if (!dustClient) {
+        throw new Error("Wallet/client not ready");
+      }
+      const coords = post.coords;
+      if (!coords || typeof coords.x !== "number") {
+        throw new Error("Post has no anchor/coordinates to set a waypoint for");
+      }
+      const bx = Math.floor(coords.x);
+      const by = Math.floor(coords.y);
+      const bz = Math.floor(coords.z);
+      const entityId = encodeBlock([bx, by, bz]);
+
+      await dustClient.provider.request({
+        method: "setWaypoint",
+        params: { entity: entityId, label: post.title || "Waypoint" },
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("Failed to set waypoint", e);
+      toast.error("Failed to Set Waypoint", {
+        description: (e as Error).message,
+      });
+    }
+  };
+
+  return { onSetWaypoint };
+};

--- a/packages/app/src/components/ArticleCard.tsx
+++ b/packages/app/src/components/ArticleCard.tsx
@@ -14,6 +14,7 @@ export const ArticleCard = ({
   compact?: boolean;
 }) => {
   const [imgLoaded, setImgLoaded] = useState(false);
+
   return (
     <article className="relative">
       <h3

--- a/packages/app/src/components/Masthead.tsx
+++ b/packages/app/src/components/Masthead.tsx
@@ -51,8 +51,6 @@ export const Masthead = () => {
     });
   }, []);
 
-  const handleClose = useCallback(() => setOpen(false), []);
-
   const handleUnpin = useCallback(() => {
     setPinned(false);
     setOpen(false);
@@ -130,9 +128,7 @@ export const Masthead = () => {
       </div>
 
       {/* Pinned app mount */}
-      {open && (
-        <PinnedApp open={open} onClose={handleClose} onUnpin={handleUnpin} />
-      )}
+      {open && <PinnedApp open={open} onUnpin={handleUnpin} />}
     </header>
   );
 };

--- a/packages/app/src/components/NoteCard.tsx
+++ b/packages/app/src/components/NoteCard.tsx
@@ -1,9 +1,9 @@
-import { encodeBlock } from "@dust/world/internal";
 import { toast } from "sonner";
 
 import { useCopy } from "@/common/useCopy";
 import { useDustClient } from "@/common/useDustClient";
 import { usePlayerName } from "@/common/usePlayerName";
+import { useWaypoint } from "@/common/useWaypoint";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { formatDate, shortenAddress } from "@/utils/helpers";
@@ -13,36 +13,7 @@ export const NoteCard = ({ note }: { note: Post }) => {
   const { data: dustClient } = useDustClient();
   const { playerName } = usePlayerName(note.owner);
   const { copyToClipboard } = useCopy();
-
-  // Set waypoint for an note by encoding its block coords into an EntityId
-  const onSetWaypoint = async (note: Post) => {
-    if (!dustClient) {
-      alert("Wallet/client not ready");
-      return;
-    }
-
-    const coords = note.coords;
-    if (!coords || typeof coords.x !== "number") {
-      alert("Note has no anchor/coordinates to set a waypoint for");
-      return;
-    }
-
-    try {
-      const bx = Math.floor(coords.x);
-      const by = Math.floor(coords.y);
-      const bz = Math.floor(coords.z);
-      const entityId = encodeBlock([bx, by, bz]);
-
-      await dustClient.provider.request({
-        method: "setWaypoint",
-        params: { entity: entityId, label: note.title || "Waypoint" },
-      });
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.warn("Failed to set waypoint", e);
-      alert("Failed to set waypoint");
-    }
-  };
+  const { onSetWaypoint } = useWaypoint();
 
   return (
     <div

--- a/packages/app/src/components/NoteCard.tsx
+++ b/packages/app/src/components/NoteCard.tsx
@@ -1,19 +1,17 @@
 import { encodeBlock } from "@dust/world/internal";
-import { getRecord } from "@latticexyz/stash/internal";
-import { useMemo } from "react";
 import { toast } from "sonner";
-import { hexToString, zeroAddress } from "viem";
 
 import { useCopy } from "@/common/useCopy";
 import { useDustClient } from "@/common/useDustClient";
+import { usePlayerName } from "@/common/usePlayerName";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { stash, tables } from "@/mud/stash";
 import { formatDate, shortenAddress } from "@/utils/helpers";
 import type { Post } from "@/utils/types";
 
 export const NoteCard = ({ note }: { note: Post }) => {
   const { data: dustClient } = useDustClient();
+  const { playerName } = usePlayerName(note.owner);
   const { copyToClipboard } = useCopy();
 
   // Set waypoint for an note by encoding its block coords into an EntityId
@@ -46,19 +44,6 @@ export const NoteCard = ({ note }: { note: Post }) => {
     }
   };
 
-  const author = useMemo(() => {
-    const ownerUsername = getRecord({
-      stash,
-      table: tables.PlayerName,
-      key: { player: (note?.owner ?? zeroAddress) as `0x${string}` },
-    })?.name;
-
-    if (ownerUsername) {
-      return hexToString(ownerUsername).replace(/\0+$/, "");
-    }
-    return "Anonymous";
-  }, [note?.owner]);
-
   return (
     <div
       key={note.id}
@@ -88,7 +73,7 @@ export const NoteCard = ({ note }: { note: Post }) => {
               toast.success(`Copied ${shortenAddress(note.owner)}`);
             }}
           >
-            @{author}
+            @{playerName}
           </button>
         </div>
       </div>

--- a/packages/app/src/components/PinnedApp.tsx
+++ b/packages/app/src/components/PinnedApp.tsx
@@ -1,10 +1,8 @@
-import { getRecord } from "@latticexyz/stash/internal";
-import { useRecords } from "@latticexyz/stash/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useDustClient } from "@/common/useDustClient";
-import { stash, tables } from "@/mud/stash";
+import { usePlayerPositionQuery } from "@/common/usePlayerPositionQuery";
+import { usePosts } from "@/common/usePosts";
 import { ARTICLE_PAGE_PATH } from "@/Routes";
 import { getDistance } from "@/utils/helpers";
 import type { Post } from "@/utils/types";
@@ -13,143 +11,26 @@ import { PinnedAppView } from "./PinnedAppView";
 
 type Props = {
   open: boolean;
-  onClose: () => void;
   onUnpin: () => void;
 };
 
-export const PinnedApp: React.FC<Props> = ({ open, onClose, onUnpin }) => {
-  const { data: dustClient } = useDustClient();
+export const PinnedApp: React.FC<Props> = ({ open, onUnpin }) => {
   const navigate = useNavigate();
-
-  const posts = useRecords({
-    stash,
-    table: tables.Post,
-  })
-    .map((r): Post => {
-      const isArticle =
-        getRecord({
-          stash,
-          table: tables.IsArticle,
-          key: { id: r.id as `0x${string}` },
-        })?.value ?? false;
-      let category: null | string = null;
-
-      const anchor =
-        getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
-        null;
-
-      const excerpt =
-        typeof r.content === "string"
-          ? (r.content.split("\n\n")[0] || r.content).slice(0, 240)
-          : "";
-
-      if (r.categories[0]) {
-        category =
-          getRecord({
-            stash,
-            table: tables.Category,
-            key: { id: r.categories[0] as `0x${string}` },
-          })?.value ?? null;
-      }
-
-      return {
-        id: r.id,
-        categories: category ? [category] : [],
-        content: (typeof r.content === "string"
-          ? r.content.split("\n\n")
-          : []) as string[],
-        coords: anchor
-          ? { x: anchor.coordX, y: anchor.coordY, z: anchor.coordZ }
-          : null,
-        createdAt: r.createdAt,
-        coverImage: r.coverImage || "/assets/placeholder-notext.png",
-        distance: null,
-        excerpt,
-        owner: r.owner,
-        title: r.title,
-        type: isArticle ? "article" : "note",
-        updatedAt: r.updatedAt,
-      };
-    })
-    .filter((r) => r.type === "article")
-    .sort((a, b) => Number(b.createdAt - a.createdAt));
-
-  const [pos, setPos] = useState<{ x: number; y: number; z: number } | null>(
-    null
-  );
-
-  // log when pos changes
-  useEffect(() => {
-    // console.log && console.log('[PinnedApp] pos changed', { pos });
-  }, [pos]);
-
-  const isFetching = useRef(false);
-  const posRef = useRef(pos);
-  useEffect(() => {
-    posRef.current = pos;
-  }, [pos]);
-
-  const fetchPos = useCallback(async () => {
-    if (!dustClient) return;
-    if (isFetching.current) return;
-    isFetching.current = true;
-    try {
-      const p = await dustClient.provider.request({
-        method: "getPlayerPosition",
-        params: { entity: dustClient.appContext?.userAddress },
-      });
-      if (p && typeof p.x === "number") {
-        const next = {
-          x: Math.floor(p.x),
-          y: Math.floor(p.y),
-          z: Math.floor(p.z),
-        };
-        if (
-          !posRef.current ||
-          posRef.current.x !== next.x ||
-          posRef.current.y !== next.y ||
-          posRef.current.z !== next.z
-        ) {
-          setPos(next);
-          posRef.current = next;
-        }
-      }
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error("[PinnedApp] fetchPos error", e);
-    } finally {
-      isFetching.current = false;
-    }
-  }, [dustClient]);
-
-  useEffect(() => {
-    if (!open || !dustClient) return;
-    fetchPos();
-    const id = setInterval(fetchPos, 5000);
-    return () => {
-      clearInterval(id);
-    };
-  }, [dustClient, fetchPos, open]);
-
-  // when posts list changes while open and dustClient is ready, trigger a fetch so closest updates immediately
-  useEffect(() => {
-    if (open && posts.length && dustClient) {
-      fetchPos();
-    }
-  }, [fetchPos, open, posts.length, dustClient]);
+  const { data: playerPosition } = usePlayerPositionQuery();
+  const { articles } = usePosts();
 
   const closestPost = useMemo(() => {
-    if (!pos) return posts[0];
-    const postsByDistance = posts
+    if (!playerPosition) return articles[0];
+    const articlesByDistance = articles
       .filter((a) => !!a.coords)
       .map((p) => ({
         ...p,
-        distance: p.coords ? getDistance(pos, p.coords) : null,
+        distance: p.coords ? getDistance(playerPosition, p.coords) : null,
       }))
       .sort((a, b) => (a.distance ?? 0) - (b.distance ?? 0));
 
-    return postsByDistance[0] ?? null;
-  }, [pos, posts]);
+    return articlesByDistance[0] ?? null;
+  }, [articles, playerPosition]);
 
   // keep a state-backed `closestState` so the UI updates reliably when the memoized
   // `closest` value changes
@@ -179,15 +60,13 @@ export const PinnedApp: React.FC<Props> = ({ open, onClose, onUnpin }) => {
         onOpenArticle={() => {
           if (closestState) {
             navigate(`${ARTICLE_PAGE_PATH}${closestState.id}`);
-            onClose();
+            onUnpin();
           }
         }}
         onUnpin={() => {
           localStorage.setItem("pinnedApp", "false");
           onUnpin();
         }}
-        onRefresh={() => fetchPos()}
-        onClose={onClose}
       />
     </div>
   );

--- a/packages/app/src/components/PinnedApp.tsx
+++ b/packages/app/src/components/PinnedApp.tsx
@@ -29,7 +29,7 @@ export const PinnedApp: React.FC<Props> = ({ open, onUnpin }) => {
       }))
       .sort((a, b) => (a.distance ?? 0) - (b.distance ?? 0));
 
-    return articlesByDistance[0] ?? null;
+    return articlesByDistance[0] ?? articles[0];
   }, [articles, playerPosition]);
 
   // keep a state-backed `closestState` so the UI updates reliably when the memoized

--- a/packages/app/src/components/PinnedAppView.tsx
+++ b/packages/app/src/components/PinnedAppView.tsx
@@ -1,4 +1,4 @@
-import { Newspaper, Pin, X } from "lucide-react";
+import { Newspaper, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -6,16 +6,12 @@ type Props = {
   closest: { id: string; title: string } | null;
   onOpenArticle: () => void;
   onUnpin: () => void;
-  onRefresh: () => void;
-  onClose: () => void;
 };
 
 export const PinnedAppView: React.FC<Props> = ({
   closest,
   onOpenArticle,
   onUnpin,
-  onRefresh,
-  onClose,
 }) => {
   return (
     <div className="bg-[#f9f7f1] border border-neutral-800 rounded-md shadow-[0_2px_0_0_#111] p-3 w-64">
@@ -46,20 +42,6 @@ export const PinnedAppView: React.FC<Props> = ({
             className="p-1 border border-neutral-800 rounded-sm bg-neutral-100"
           >
             <X className="size-4 text-neutral-800" />
-          </button>
-          <button
-            title="Refresh"
-            onClick={onRefresh}
-            className="p-1 border border-neutral-800 rounded-sm bg-neutral-100"
-          >
-            ⟳
-          </button>
-          <button
-            title="Close"
-            onClick={onClose}
-            className="p-1 border border-neutral-800 rounded-sm bg-neutral-100"
-          >
-            <Pin className="size-4 text-neutral-800" />
           </button>
         </div>
       </div>

--- a/packages/app/src/components/editor/ArticleWizard.tsx
+++ b/packages/app/src/components/editor/ArticleWizard.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from "react";
 import { toast } from "sonner";
 import type { Abi } from "viem";
 
+import { useCategories } from "@/common/useCategories";
 import { useDustClient } from "@/common/useDustClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { stash, tables } from "@/mud/stash";
@@ -208,8 +209,8 @@ export const ArticleWizard: React.FC<Props> = ({
   onCancel,
 }) => {
   const { data: dustClient } = useDustClient();
+  const { articleCategories } = useCategories();
 
-  const [articleCategories, setArticleCategories] = useState<string[]>([]);
   const [step, setStep] = useState<1 | 2 | 3>(1);
   const [title, setTitle] = useState("");
   const [coverImage, setCoverImage] = useState("");
@@ -226,31 +227,8 @@ export const ArticleWizard: React.FC<Props> = ({
   } | null>(null);
 
   useEffect(() => {
-    const categories = (getRecord({
-      stash,
-      table: tables.ArticleCategories,
-      key: {},
-    })
-      ?.value?.map((c) => {
-        return getRecord({
-          stash,
-          table: tables.Category,
-          key: { id: c },
-        })?.value;
-      })
-      .filter((c): c is string => !!c) ?? []) as string[];
-
-    setArticleCategories(categories);
-    setCategory(categories[0] ?? "");
-  }, []);
-
-  // If the category hasn't been set by the user or by loading an article/draft,
-  // default to the first available category when the list becomes available.
-  useEffect(() => {
-    if (!category && articleCategories.length > 0) {
-      setCategory(articleCategories[0]);
-    }
-  }, [articleCategories, category]);
+    setCategory(articleCategories[0] ?? "");
+  }, [articleCategories]);
 
   useEffect(() => {
     // hydrate from draft or articleId (basic)

--- a/packages/app/src/components/editor/ArticleWizard.tsx
+++ b/packages/app/src/components/editor/ArticleWizard.tsx
@@ -227,8 +227,10 @@ export const ArticleWizard: React.FC<Props> = ({
   } | null>(null);
 
   useEffect(() => {
-    setCategory(articleCategories[0] ?? "");
-  }, [articleCategories]);
+    // Only choose a default when creating a new article and category isn't set yet
+    if (articleId) return;
+    if (!category) setCategory(articleCategories[0] ?? "");
+  }, [articleCategories, articleId, category]);
 
   useEffect(() => {
     // hydrate from draft or articleId (basic)
@@ -367,7 +369,18 @@ export const ArticleWizard: React.FC<Props> = ({
           else setCoverImage("");
           setTitle(rec.title ?? "");
           setContent(rec.content ?? "");
+          setCategory(rec.categories[0] ?? "");
           setDraftLocalId(null);
+
+          const articleCategoryId = rec.categories[0] ?? "";
+          if (articleCategoryId) {
+            const articleCategory = getRecord({
+              stash,
+              table: tables.Category,
+              key: { id: articleCategoryId },
+            })?.value;
+            if (articleCategory) setCategory(articleCategory);
+          }
         }
 
         // Try to load an existing anchor for this post so preview shows anchor coords

--- a/packages/app/src/components/editor/ArticleWizardStep2.tsx
+++ b/packages/app/src/components/editor/ArticleWizardStep2.tsx
@@ -1,8 +1,4 @@
-import { getRecord } from "@latticexyz/stash/internal";
-import { useMemo } from "react";
-import { hexToString, zeroAddress } from "viem";
-
-import { stash, tables } from "@/mud/stash";
+import { usePlayerName } from "@/common/usePlayerName";
 import { uriToHttp } from "@/utils/helpers";
 
 interface Props {
@@ -24,18 +20,7 @@ export default function ArticleWizardStep2({
   authorAddress,
   category,
 }: Props) {
-  const author = useMemo(() => {
-    const ownerUsername = getRecord({
-      stash,
-      table: tables.PlayerName,
-      key: { player: (authorAddress ?? zeroAddress) as `0x${string}` },
-    })?.name;
-
-    if (ownerUsername) {
-      return hexToString(ownerUsername).replace(/\0+$/, "");
-    }
-    return "Anonymous";
-  }, [authorAddress]);
+  const { playerName } = usePlayerName(authorAddress);
 
   return (
     <div className="max-h-[60vh] overflow-y-auto bg-panel border border-neutral-200 rounded p-4">
@@ -50,7 +35,7 @@ export default function ArticleWizardStep2({
         <h1 className={"font-heading text-2xl leading-tight"}>
           {title || "Untitled"}
         </h1>
-        <div className="font-accent text-[10px] text-neutral-700">{`By ${author}`}</div>
+        <div className="font-accent text-[10px] text-neutral-700">{`By ${playerName}`}</div>
         {category && (
           <div className="mt-1">
             <span className="font-accent bg-neutral-100 border border-neutral-900 px-2 py-1 rounded-[3px] text-[10px] tracking-wider uppercase">

--- a/packages/app/src/mud/stash.ts
+++ b/packages/app/src/mud/stash.ts
@@ -10,7 +10,6 @@ import { redstone } from "./redstone";
 
 const selectedDustTables = {
   Energy: dustWorldConfig.tables.Energy,
-  EntityPosition: dustWorldConfig.tables.EntityPosition,
   PlayerName: dustWorldConfig.tables.PlayerName,
 };
 

--- a/packages/app/src/mud/stash.ts
+++ b/packages/app/src/mud/stash.ts
@@ -10,6 +10,7 @@ import { redstone } from "./redstone";
 
 const selectedDustTables = {
   Energy: dustWorldConfig.tables.Energy,
+  EntityPosition: dustWorldConfig.tables.EntityPosition,
   PlayerName: dustWorldConfig.tables.PlayerName,
 };
 

--- a/packages/app/src/pages/ArticlePage.tsx
+++ b/packages/app/src/pages/ArticlePage.tsx
@@ -1,6 +1,5 @@
 import { encodeBlock } from "@dust/world/internal";
 import { getRecord } from "@latticexyz/stash/internal";
-import { useRecords } from "@latticexyz/stash/react";
 import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -8,6 +7,7 @@ import { hexToString, zeroAddress } from "viem";
 
 import { useCopy } from "@/common/useCopy";
 import { useDustClient } from "@/common/useDustClient";
+import { usePosts } from "@/common/usePosts";
 import { cn } from "@/lib/utils";
 import { stash, tables } from "@/mud/stash";
 import { DISCOVER_PAGE_PATH, FRONT_PAGE_PATH } from "@/Routes";
@@ -18,6 +18,7 @@ export const ArticlePage = () => {
   const { id } = useParams<{ id: string }>();
   const { data: dustClient } = useDustClient();
   const { copyToClipboard } = useCopy();
+  const { articles } = usePosts();
 
   // Set waypoint for the currently viewed article (uses block-entity encoding)
   const onSetWaypoint = async (art: Post) => {
@@ -49,60 +50,10 @@ export const ArticlePage = () => {
     }
   };
 
-  const posts = useRecords({
-    stash,
-    table: tables.Post,
-  })
-    .map((r): Post => {
-      const isArticle =
-        getRecord({
-          stash,
-          table: tables.IsArticle,
-          key: { id: r.id as `0x${string}` },
-        })?.value ?? false;
-      let category: null | string = null;
-
-      const anchor =
-        getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
-        null;
-
-      const excerpt =
-        typeof r.content === "string"
-          ? (r.content.split("\n\n")[0] || r.content).slice(0, 240)
-          : "";
-
-      if (r.categories[0]) {
-        category =
-          getRecord({
-            stash,
-            table: tables.Category,
-            key: { id: r.categories[0] as `0x${string}` },
-          })?.value ?? null;
-      }
-
-      return {
-        id: r.id,
-        categories: category ? [category] : [],
-        content: (typeof r.content === "string"
-          ? r.content.split("\n\n")
-          : []) as string[],
-        coords: anchor
-          ? { x: anchor.coordX, y: anchor.coordY, z: anchor.coordZ }
-          : null,
-        createdAt: r.createdAt,
-        coverImage: r.coverImage || "/assets/placeholder-notext.png",
-        distance: null,
-        excerpt,
-        owner: r.owner,
-        title: r.title,
-        type: isArticle ? "article" : "note",
-        updatedAt: r.updatedAt,
-      };
-    })
-    .filter((r) => r.type === "article")
-    .sort((a, b) => Number(b.createdAt - a.createdAt));
-
-  const article = useMemo(() => posts.find((p) => p.id === id), [id, posts]);
+  const article = useMemo(
+    () => articles.find((p) => p.id === id),
+    [id, articles]
+  );
 
   const author = useMemo(() => {
     const ownerUsername = getRecord({

--- a/packages/app/src/pages/ArticlePage.tsx
+++ b/packages/app/src/pages/ArticlePage.tsx
@@ -1,4 +1,3 @@
-import { encodeBlock } from "@dust/world/internal";
 import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -7,46 +6,17 @@ import { useCopy } from "@/common/useCopy";
 import { useDustClient } from "@/common/useDustClient";
 import { usePlayerName } from "@/common/usePlayerName";
 import { usePosts } from "@/common/usePosts";
+import { useWaypoint } from "@/common/useWaypoint";
 import { cn } from "@/lib/utils";
 import { DISCOVER_PAGE_PATH, FRONT_PAGE_PATH } from "@/Routes";
 import { formatDate, shortenAddress, uriToHttp } from "@/utils/helpers";
-import type { Post } from "@/utils/types";
 
 export const ArticlePage = () => {
   const { id } = useParams<{ id: string }>();
   const { data: dustClient } = useDustClient();
   const { copyToClipboard } = useCopy();
   const { articles } = usePosts();
-
-  // Set waypoint for the currently viewed article (uses block-entity encoding)
-  const onSetWaypoint = async (art: Post) => {
-    if (!dustClient) {
-      alert("Wallet/client not ready");
-      return;
-    }
-
-    const coords = art?.coords;
-    if (!coords || typeof coords.x !== "number") {
-      alert("Article has no anchor/coordinates to set a waypoint for");
-      return;
-    }
-
-    try {
-      const bx = Math.floor(coords.x);
-      const by = Math.floor(coords.y);
-      const bz = Math.floor(coords.z);
-      const entityId = encodeBlock([bx, by, bz]);
-
-      await dustClient.provider.request({
-        method: "setWaypoint",
-        params: { entity: entityId, label: art.title || "Waypoint" },
-      });
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.warn("Failed to set waypoint", e);
-      alert("Failed to set waypoint");
-    }
-  };
+  const { onSetWaypoint } = useWaypoint();
 
   const article = useMemo(
     () => articles.find((p) => p.id === id),

--- a/packages/app/src/pages/ArticlePage.tsx
+++ b/packages/app/src/pages/ArticlePage.tsx
@@ -1,15 +1,13 @@
 import { encodeBlock } from "@dust/world/internal";
-import { getRecord } from "@latticexyz/stash/internal";
 import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import { toast } from "sonner";
-import { hexToString, zeroAddress } from "viem";
 
 import { useCopy } from "@/common/useCopy";
 import { useDustClient } from "@/common/useDustClient";
+import { usePlayerName } from "@/common/usePlayerName";
 import { usePosts } from "@/common/usePosts";
 import { cn } from "@/lib/utils";
-import { stash, tables } from "@/mud/stash";
 import { DISCOVER_PAGE_PATH, FRONT_PAGE_PATH } from "@/Routes";
 import { formatDate, shortenAddress, uriToHttp } from "@/utils/helpers";
 import type { Post } from "@/utils/types";
@@ -55,18 +53,7 @@ export const ArticlePage = () => {
     [id, articles]
   );
 
-  const author = useMemo(() => {
-    const ownerUsername = getRecord({
-      stash,
-      table: tables.PlayerName,
-      key: { player: (article?.owner ?? zeroAddress) as `0x${string}` },
-    })?.name;
-
-    if (ownerUsername) {
-      return hexToString(ownerUsername).replace(/\0+$/, "");
-    }
-    return "Anonymous";
-  }, [article?.owner]);
+  const { playerName } = usePlayerName(article?.owner);
 
   if (!article) {
     return (
@@ -123,7 +110,7 @@ export const ArticlePage = () => {
               toast.success(`Copied ${shortenAddress(article.owner)}`);
             }}
           >
-            @{author}
+            @{playerName}
           </button>
           {" • "}
           {formatDate(article.createdAt)}

--- a/packages/app/src/pages/BackPage.tsx
+++ b/packages/app/src/pages/BackPage.tsx
@@ -1,6 +1,5 @@
 import { encodeBlock } from "@dust/world/internal";
 import { resourceToHex } from "@latticexyz/common";
-import { getRecord } from "@latticexyz/stash/internal";
 import { useMutation } from "@tanstack/react-query";
 import mudConfig from "contracts/mud.config";
 import NoteSystemAbi from "contracts/out/NoteSystem.sol/NoteSystem.abi.json";
@@ -9,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { Abi } from "viem";
 
+import { useCategories } from "@/common/useCategories";
 import { useDustClient } from "@/common/useDustClient";
 import { usePlayerPositionQuery } from "@/common/usePlayerPositionQuery";
 import { usePosts } from "@/common/usePosts";
@@ -18,7 +18,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { stash, tables } from "@/mud/stash";
 import { POPULAR_PLACES } from "@/utils/constants";
 import { getDistance, parseCoords } from "@/utils/helpers";
 
@@ -26,8 +25,8 @@ export const BackPage = () => {
   const { data: dustClient } = useDustClient();
   const { data: playerPosition } = usePlayerPositionQuery();
   const { notes } = usePosts();
+  const { noteCategories } = useCategories();
 
-  const [noteCategories, setNoteCategories] = useState<string[]>([]);
   const [isNewNoteDialogOpen, setIsNewNoteDialogOpen] = useState(false);
   const [form, setForm] = useState({
     title: "",
@@ -96,26 +95,11 @@ export const BackPage = () => {
   }, [coords, notesByDistance, q, selectedCategory, authorFilter, dateSort]);
 
   useEffect(() => {
-    const categories = (getRecord({
-      stash,
-      table: tables.NoteCategories,
-      key: {},
-    })
-      ?.value?.map((c) => {
-        return getRecord({
-          stash,
-          table: tables.Category,
-          key: { id: c },
-        })?.value;
-      })
-      .filter((c): c is string => !!c) ?? []) as string[];
-
-    setNoteCategories(categories);
     setForm((f) => ({
       ...f,
-      category: categories[0] ?? "",
+      category: noteCategories[0] ?? "",
     }));
-  }, []);
+  }, [noteCategories]);
 
   const onResetCurrentPos = async () => {
     if (!dustClient) return;

--- a/packages/app/src/pages/BackPage.tsx
+++ b/packages/app/src/pages/BackPage.tsx
@@ -1,7 +1,6 @@
 import { encodeBlock } from "@dust/world/internal";
 import { resourceToHex } from "@latticexyz/common";
 import { getRecord } from "@latticexyz/stash/internal";
-import { useRecords } from "@latticexyz/stash/react";
 import { useMutation } from "@tanstack/react-query";
 import mudConfig from "contracts/mud.config";
 import NoteSystemAbi from "contracts/out/NoteSystem.sol/NoteSystem.abi.json";
@@ -11,6 +10,8 @@ import { toast } from "sonner";
 import type { Abi } from "viem";
 
 import { useDustClient } from "@/common/useDustClient";
+import { usePlayerPositionQuery } from "@/common/usePlayerPositionQuery";
+import { usePosts } from "@/common/usePosts";
 import { NoteCard } from "@/components/NoteCard";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,10 +21,11 @@ import { cn } from "@/lib/utils";
 import { stash, tables } from "@/mud/stash";
 import { POPULAR_PLACES } from "@/utils/constants";
 import { getDistance, parseCoords } from "@/utils/helpers";
-import type { Post } from "@/utils/types";
 
 export const BackPage = () => {
   const { data: dustClient } = useDustClient();
+  const { data: playerPosition } = usePlayerPositionQuery();
+  const { notes } = usePosts();
 
   const [noteCategories, setNoteCategories] = useState<string[]>([]);
   const [isNewNoteDialogOpen, setIsNewNoteDialogOpen] = useState(false);
@@ -32,12 +34,6 @@ export const BackPage = () => {
     content: "",
     category: "",
   });
-  // Anchor position (block coords) shown in preview and used for best-effort anchor creation
-  const [anchorPos, setAnchorPos] = useState<{
-    x: number;
-    y: number;
-    z: number;
-  } | null>(null);
 
   const [showPosFilters, setShowPosFilters] = useState(false);
 
@@ -47,69 +43,21 @@ export const BackPage = () => {
   const [authorFilter, setAuthorFilter] = useState<string>("");
   const [dateSort, setDateSort] = useState<"newest" | "oldest">("newest");
 
-  const posts = useRecords({
-    stash,
-    table: tables.Post,
-  })
-    .map((r): Post => {
-      const isNote =
-        getRecord({
-          stash,
-          table: tables.IsNote,
-          key: { id: r.id as `0x${string}` },
-        })?.value ?? false;
-      let category: null | string = null;
-
-      const anchor =
-        getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
-        null;
-
-      if (r.categories[0]) {
-        category =
-          getRecord({
-            stash,
-            table: tables.Category,
-            key: { id: r.categories[0] as `0x${string}` },
-          })?.value ?? null;
-      }
-
-      return {
-        id: r.id,
-        categories: category ? [category] : [],
-        content: (typeof r.content === "string"
-          ? r.content.split("\n\n")
-          : []) as string[],
-        coords: anchor
-          ? { x: anchor.coordX, y: anchor.coordY, z: anchor.coordZ }
-          : null,
-        createdAt: r.createdAt,
-        coverImage: r.coverImage || "/assets/placeholder-notext.png",
-        distance: null,
-        excerpt: "",
-        owner: r.owner,
-        title: r.title,
-        type: isNote ? "note" : "article",
-        updatedAt: r.updatedAt,
-      };
-    })
-    .filter((r) => r.type === "note")
-    .sort((a, b) => Number(b.createdAt - a.createdAt));
-
   const parsedCoords = useMemo(
     () => (coords ? parseCoords(coords) : null),
     [coords]
   );
 
   const notesByDistance = useMemo(() => {
-    if (!parsedCoords) return posts;
-    return posts
+    if (!parsedCoords) return notes;
+    return notes
       .filter((a) => !!a.coords)
       .map((p) => ({
         ...p,
         distance: p.coords ? getDistance(parsedCoords, p.coords) : null,
       }))
       .sort((a, b) => (a.distance ?? 0) - (b.distance ?? 0));
-  }, [parsedCoords, posts]);
+  }, [notes, parsedCoords]);
 
   const filteredNotes = useMemo(() => {
     const term = q.trim().toLowerCase();
@@ -168,34 +116,6 @@ export const BackPage = () => {
       category: categories[0] ?? "",
     }));
   }, []);
-
-  // Fetch current player position (best-effort) to show anchor in preview when creating a new article
-  useEffect(() => {
-    if (!dustClient) return;
-
-    let cancelled = false;
-    (async () => {
-      try {
-        const pos = await dustClient.provider.request({
-          method: "getPlayerPosition",
-          params: { entity: dustClient.appContext?.userAddress },
-        });
-        if (cancelled) return;
-        setAnchorPos({
-          x: Math.floor(pos.x),
-          y: Math.floor(pos.y),
-          z: Math.floor(pos.z),
-        });
-      } catch (e) {
-        // preview anchor is optional
-        // eslint-disable-next-line no-console
-        console.warn("Could not fetch player position for preview anchor", e);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [dustClient]);
 
   const onResetCurrentPos = async () => {
     if (!dustClient) return;
@@ -296,12 +216,12 @@ export const BackPage = () => {
       if (!form.title || !form.content) return;
 
       try {
-        if (anchorPos) {
+        if (playerPosition) {
           await createNoteWithAnchor.mutateAsync({
             title: form.title,
             content: form.content,
             category: form.category,
-            anchorPos,
+            anchorPos: playerPosition,
           });
         } else {
           await createNote.mutateAsync({
@@ -321,7 +241,7 @@ export const BackPage = () => {
         });
       }
     },
-    [anchorPos, createNote, createNoteWithAnchor, form]
+    [createNote, createNoteWithAnchor, form, playerPosition]
   );
 
   const isDisabled = useMemo(() => {
@@ -418,8 +338,8 @@ export const BackPage = () => {
                 </form>
                 <footer className="border-neutral-900 border-t flex flex-wrap gap-3 items-center justify-between mt-6 pt-3">
                   <div className={"font-accent text-[10px] text-neutral-700"}>
-                    {anchorPos
-                      ? `${"Preview anchor"} • x:${anchorPos.x} y:${anchorPos.y} z:${anchorPos.z}`
+                    {playerPosition
+                      ? `${"Preview anchor"} • x:${playerPosition.x} y:${playerPosition.y} z:${playerPosition.z}`
                       : "No anchor"}
                   </div>
                 </footer>

--- a/packages/app/src/pages/DiscoverPage.tsx
+++ b/packages/app/src/pages/DiscoverPage.tsx
@@ -1,25 +1,22 @@
 import { encodeBlock } from "@dust/world/internal";
 import { getRecord } from "@latticexyz/stash/internal";
-import { useRecord, useRecords } from "@latticexyz/stash/react";
-import { useEffect, useMemo, useState } from "react";
+import { useRecord } from "@latticexyz/stash/react";
+import { useMemo, useState } from "react";
 
 import { useDustClient } from "@/common/useDustClient";
+import { usePosts } from "@/common/usePosts";
 import { ArticleCard } from "@/components/ArticleCard";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { stash, tables } from "@/mud/stash";
-import { getDistance } from "@/utils/helpers";
 import type { Post } from "@/utils/types";
 
 export const DiscoverPage = () => {
   const { data: dustClient } = useDustClient();
-  const [currentPos, setCurrentPos] = useState<{
-    x: number;
-    y: number;
-    z: number;
-  } | null>(null);
+  const { articles } = usePosts();
+
   const [q, setQ] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
   const [authorFilter, setAuthorFilter] = useState<string>("");
@@ -39,68 +36,10 @@ export const DiscoverPage = () => {
     })
     .filter((c): c is string => !!c) ?? []) as string[];
 
-  const posts = useRecords({
-    stash,
-    table: tables.Post,
-  })
-    .map((r): Post => {
-      const isArticle =
-        getRecord({
-          stash,
-          table: tables.IsArticle,
-          key: { id: r.id as `0x${string}` },
-        })?.value ?? false;
-      let category: null | string = null;
-
-      const anchor =
-        getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
-        null;
-
-      const excerpt =
-        typeof r.content === "string"
-          ? (r.content.split("\n\n")[0] || r.content).slice(0, 240)
-          : "";
-
-      if (r.categories[0]) {
-        category =
-          getRecord({
-            stash,
-            table: tables.Category,
-            key: { id: r.categories[0] as `0x${string}` },
-          })?.value ?? null;
-      }
-
-      return {
-        id: r.id,
-        categories: category ? [category] : [],
-        content: (typeof r.content === "string"
-          ? r.content.split("\n\n")
-          : []) as string[],
-        coords: anchor
-          ? { x: anchor.coordX, y: anchor.coordY, z: anchor.coordZ }
-          : null,
-        createdAt: r.createdAt,
-        coverImage: r.coverImage || "/assets/placeholder-notext.png",
-        distance: null,
-        excerpt,
-        owner: r.owner,
-        title: r.title,
-        type: isArticle ? "article" : "note",
-        updatedAt: r.updatedAt,
-      };
-    })
-    .filter((r) => r.type === "article")
-    .map((p) => ({
-      ...p,
-      distance:
-        p.coords && currentPos ? getDistance(currentPos, p.coords) : null,
-    }))
-    .sort((a, b) => Number(b.createdAt - a.createdAt));
-
-  const filteredPosts = useMemo(() => {
+  const filteredArticles = useMemo(() => {
     const term = q.trim().toLowerCase();
 
-    let results = posts.slice();
+    let results = articles.slice();
 
     if (selectedCategory) {
       results = results.filter((a) =>
@@ -132,29 +71,7 @@ export const DiscoverPage = () => {
     });
 
     return results;
-  }, [posts, q, selectedCategory, authorFilter, dateSort]);
-
-  useEffect(() => {
-    (async () => {
-      if (!dustClient) return;
-      try {
-        const pos = await dustClient.provider.request({
-          method: "getPlayerPosition",
-          params: { entity: dustClient.appContext?.userAddress },
-        });
-        if (pos && typeof pos.x === "number") {
-          setCurrentPos({
-            x: Math.floor(pos.x),
-            y: Math.floor(pos.y),
-            z: Math.floor(pos.z),
-          });
-        }
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn("Failed to fetch current position", e);
-      }
-    })();
-  }, [dustClient]);
+  }, [articles, q, selectedCategory, authorFilter, dateSort]);
 
   const onSetWaypoint = async (article: Post) => {
     if (!dustClient) {
@@ -243,7 +160,7 @@ export const DiscoverPage = () => {
       <Card className="border-neutral-900">
         <CardContent className="p-4">
           <div className="gap-6 grid md:grid-cols-2">
-            {filteredPosts.map((a) => (
+            {filteredArticles.map((a) => (
               <div key={a.id} className="border-neutral-900 border-t pt-3">
                 <ArticleCard article={a} />
                 {a.distance !== null && (
@@ -265,7 +182,7 @@ export const DiscoverPage = () => {
                 )}
               </div>
             ))}
-            {filteredPosts.length === 0 && (
+            {filteredArticles.length === 0 && (
               <div className="text-neutral-600 text-sm">No results found.</div>
             )}
           </div>

--- a/packages/app/src/pages/DiscoverPage.tsx
+++ b/packages/app/src/pages/DiscoverPage.tsx
@@ -1,8 +1,7 @@
 import { encodeBlock } from "@dust/world/internal";
-import { getRecord } from "@latticexyz/stash/internal";
-import { useRecord } from "@latticexyz/stash/react";
 import { useMemo, useState } from "react";
 
+import { useCategories } from "@/common/useCategories";
 import { useDustClient } from "@/common/useDustClient";
 import { usePosts } from "@/common/usePosts";
 import { ArticleCard } from "@/components/ArticleCard";
@@ -10,31 +9,17 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { stash, tables } from "@/mud/stash";
 import type { Post } from "@/utils/types";
 
 export const DiscoverPage = () => {
   const { data: dustClient } = useDustClient();
   const { articles } = usePosts();
+  const { articleCategories } = useCategories();
 
   const [q, setQ] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
   const [authorFilter, setAuthorFilter] = useState<string>("");
   const [dateSort, setDateSort] = useState<"newest" | "oldest">("newest");
-
-  const articleCategories = (useRecord({
-    stash,
-    table: tables.ArticleCategories,
-    key: {},
-  })
-    ?.value?.map((c) => {
-      return getRecord({
-        stash,
-        table: tables.Category,
-        key: { id: c },
-      })?.value;
-    })
-    .filter((c): c is string => !!c) ?? []) as string[];
 
   const filteredArticles = useMemo(() => {
     const term = q.trim().toLowerCase();

--- a/packages/app/src/pages/DiscoverPage.tsx
+++ b/packages/app/src/pages/DiscoverPage.tsx
@@ -1,20 +1,20 @@
-import { encodeBlock } from "@dust/world/internal";
 import { useMemo, useState } from "react";
 
 import { useCategories } from "@/common/useCategories";
 import { useDustClient } from "@/common/useDustClient";
 import { usePosts } from "@/common/usePosts";
+import { useWaypoint } from "@/common/useWaypoint";
 import { ArticleCard } from "@/components/ArticleCard";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import type { Post } from "@/utils/types";
 
 export const DiscoverPage = () => {
   const { data: dustClient } = useDustClient();
   const { articles } = usePosts();
   const { articleCategories } = useCategories();
+  const { onSetWaypoint } = useWaypoint();
 
   const [q, setQ] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
@@ -57,33 +57,6 @@ export const DiscoverPage = () => {
 
     return results;
   }, [articles, q, selectedCategory, authorFilter, dateSort]);
-
-  const onSetWaypoint = async (article: Post) => {
-    if (!dustClient) {
-      alert("Wallet/client not ready");
-      return;
-    }
-    const coords = article.coords;
-    if (!coords || typeof coords.x !== "number") {
-      alert("Article has no anchor/coordinates to set a waypoint for");
-      return;
-    }
-    try {
-      const bx = Math.floor(coords.x);
-      const by = Math.floor(coords.y);
-      const bz = Math.floor(coords.z);
-      const entityId = encodeBlock([bx, by, bz]);
-
-      await dustClient.provider.request({
-        method: "setWaypoint",
-        params: { entity: entityId, label: article.title || "Waypoint" },
-      });
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.warn("Failed to set waypoint", e);
-      alert("Failed to set waypoint");
-    }
-  };
 
   return (
     <div className="gap-6 p-4 sm:p-6 grid">

--- a/packages/app/src/pages/EditorRoomPage.tsx
+++ b/packages/app/src/pages/EditorRoomPage.tsx
@@ -2,7 +2,7 @@ import { getRecord } from "@latticexyz/stash/internal";
 import { useRecords } from "@latticexyz/stash/react";
 import { useEffect, useState } from "react";
 
-import { useDustClient } from "@/common/useDustClient";
+import { usePlayerEntityId } from "@/common/usePlayerEntityId";
 import { ArticleWizard } from "@/components/editor/ArticleWizard";
 import { PublishedList } from "@/components/editor/PublishedList";
 import { Button } from "@/components/ui/button";
@@ -13,9 +13,7 @@ import type { Post } from "@/utils/types";
 export const EditorRoomPage = () => {
   type TabKey = "published" | "drafts";
   const [tab, setTab] = useState<TabKey>("drafts");
-
-  const { data: dustClient } = useDustClient();
-  const myAddress = (dustClient?.appContext.userAddress || "").toLowerCase();
+  const { data: playerAddress } = usePlayerEntityId();
 
   // Minimal markdown -> HTML renderer (same rules as ArticleWizard)
   const renderMarkdownToHtml = (md: string) => {
@@ -323,10 +321,10 @@ export const EditorRoomPage = () => {
           </div>
         )}
 
-        {tab === "published" && (
+        {tab === "published" && playerAddress && (
           <PublishedList
             published={posts}
-            myAddress={myAddress}
+            myAddress={playerAddress}
             onEdit={(id) => openArticle(id)}
             renderMarkdownToHtml={renderMarkdownToHtml}
           />

--- a/packages/app/src/pages/EditorRoomPage.tsx
+++ b/packages/app/src/pages/EditorRoomPage.tsx
@@ -1,19 +1,13 @@
-import { getRecord } from "@latticexyz/stash/internal";
-import { useRecords } from "@latticexyz/stash/react";
 import { useEffect, useState } from "react";
 
-import { usePlayerEntityId } from "@/common/usePlayerEntityId";
 import { ArticleWizard } from "@/components/editor/ArticleWizard";
 import { PublishedList } from "@/components/editor/PublishedList";
 import { Button } from "@/components/ui/button";
-import { stash, tables } from "@/mud/stash";
 import { formatDate } from "@/utils/helpers";
-import type { Post } from "@/utils/types";
 
 export const EditorRoomPage = () => {
   type TabKey = "published" | "drafts";
   const [tab, setTab] = useState<TabKey>("drafts");
-  const { data: playerAddress } = usePlayerEntityId();
 
   // Minimal markdown -> HTML renderer (same rules as ArticleWizard)
   const renderMarkdownToHtml = (md: string) => {
@@ -107,60 +101,6 @@ export const EditorRoomPage = () => {
       {label}
     </Button>
   );
-
-  const posts = useRecords({
-    stash,
-    table: tables.Post,
-  })
-    .map((r): Post & { rawContent: string } => {
-      const isArticle =
-        getRecord({
-          stash,
-          table: tables.IsArticle,
-          key: { id: r.id as `0x${string}` },
-        })?.value ?? false;
-      let category: null | string = null;
-
-      const anchor =
-        getRecord({ stash, table: tables.PostAnchor, key: { id: r.id } }) ??
-        null;
-
-      const excerpt =
-        typeof r.content === "string"
-          ? (r.content.split("\n\n")[0] || r.content).slice(0, 240)
-          : "";
-
-      if (r.categories[0]) {
-        category =
-          getRecord({
-            stash,
-            table: tables.Category,
-            key: { id: r.categories[0] as `0x${string}` },
-          })?.value ?? null;
-      }
-
-      return {
-        id: r.id,
-        categories: category ? [category] : [],
-        content: (typeof r.content === "string"
-          ? r.content.split("\n\n")
-          : []) as string[],
-        coords: anchor
-          ? { x: anchor.coordX, y: anchor.coordY, z: anchor.coordZ }
-          : null,
-        createdAt: r.createdAt,
-        coverImage: r.coverImage || "/assets/placeholder-notext.png",
-        distance: null,
-        excerpt,
-        owner: r.owner,
-        rawContent: r.content,
-        title: r.title,
-        type: isArticle ? "article" : "note",
-        updatedAt: r.updatedAt,
-      };
-    })
-    .filter((r) => r.type === "article")
-    .sort((a, b) => Number(b.createdAt - a.createdAt));
 
   // Drafts stored in localStorage under same key as ArticleWizard
   const DRAFT_KEY = "editor-article-drafts";
@@ -321,10 +261,8 @@ export const EditorRoomPage = () => {
           </div>
         )}
 
-        {tab === "published" && playerAddress && (
+        {tab === "published" && (
           <PublishedList
-            published={posts}
-            myAddress={playerAddress}
             onEdit={(id) => openArticle(id)}
             renderMarkdownToHtml={renderMarkdownToHtml}
           />

--- a/packages/app/src/utils/types.ts
+++ b/packages/app/src/utils/types.ts
@@ -8,6 +8,7 @@ export type Post = {
   distance: number | null;
   excerpt: string;
   owner: string;
+  rawContent: string;
   title: string;
   type: PostType;
   updatedAt: bigint;


### PR DESCRIPTION
Also closes #38 

---

This pull request introduces several new React hooks to encapsulate logic for fetching categories, player names, posts, and setting waypoints, and refactors components to use these hooks. The result is a cleaner, more modular codebase with reduced duplication and improved maintainability. Additionally, the `PinnedApp` and related UI have been simplified, removing unnecessary refresh/close logic and streamlining state management.

**Hooks and Data Fetching Refactors:**

- Introduced `useCategories`, `usePlayerName`, `usePosts`, and `useWaypoint` hooks to encapsulate logic for fetching categories, player names, posts, and setting waypoints, respectively. Components such as `ArticleWizard`, `ArticleWizardStep2`, and `NoteCard` now use these hooks instead of duplicating logic. [[1]](diffhunk://#diff-3bfcbd4feddc85cd4a872de4d84bda430a3d298093252d60c3e9cf9b9c9602ffR1-R47) [[2]](diffhunk://#diff-2455a55a132970ae8bad2685485ecd387c962624721117a1f7e66c340d10c320R1-R27) [[3]](diffhunk://#diff-e302be589c91328199795cccc2794026f479887f9eff0866f918a77eabaa4e32R1-R89) [[4]](diffhunk://#diff-57f8dbde2256764b50e31fdcb6ba0b091891a706aaf7392f14786964ceb7abe5R1-R39)

**Component Simplification and Cleanup:**

- Refactored `PinnedApp` to use the new `usePosts` and `usePlayerPositionQuery` hooks, removing internal state and effect logic related to fetching posts and player position. The UI is now simpler and more reliable. [[1]](diffhunk://#diff-ae7e3ef18f723b8658ec7e15f9eb4159c3fb39dc58d9aad26a9788911ebfcb51L1-R5) [[2]](diffhunk://#diff-ae7e3ef18f723b8658ec7e15f9eb4159c3fb39dc58d9aad26a9788911ebfcb51L16-R33) [[3]](diffhunk://#diff-ae7e3ef18f723b8658ec7e15f9eb4159c3fb39dc58d9aad26a9788911ebfcb51L182-L190)
- Simplified the `PinnedAppView` component by removing the refresh and close buttons, reducing the number of props and possible user actions. [[1]](diffhunk://#diff-2aa35b71998adb7332b64d77f2c1b0c812f494362a84e831114e135c5480dd9bL1-L18) [[2]](diffhunk://#diff-2aa35b71998adb7332b64d77f2c1b0c812f494362a84e831114e135c5480dd9bL50-L63)

**Component Usage of New Hooks:**

- Updated `NoteCard` and `ArticleWizardStep2` to use the new `usePlayerName` hook for displaying author names, removing previous inline logic. [[1]](diffhunk://#diff-a375f673fa9693a38d2bd4eed7618c30c659ab041bfc7dc3294d12882be53dcbL1-R16) [[2]](diffhunk://#diff-a375f673fa9693a38d2bd4eed7618c30c659ab041bfc7dc3294d12882be53dcbL91-R47) [[3]](diffhunk://#diff-a70cfbd509a08ded64ce53368db126781dd4b1a6ffda46a260ab746cb95388b1L1-R1) [[4]](diffhunk://#diff-a70cfbd509a08ded64ce53368db126781dd4b1a6ffda46a260ab746cb95388b1L27-R23) [[5]](diffhunk://#diff-a70cfbd509a08ded64ce53368db126781dd4b1a6ffda46a260ab746cb95388b1L53-R38)
- Updated `NoteCard` to use the new `useWaypoint` hook for setting waypoints, replacing duplicated logic.
- Updated `ArticleWizard` to use the new `useCategories` hook for fetching article categories, simplifying effect logic. [[1]](diffhunk://#diff-dde629a17af2577782e565431419082c42ad932c0b667a69e1f650da47b89c16R10) [[2]](diffhunk://#diff-dde629a17af2577782e565431419082c42ad932c0b667a69e1f650da47b89c16R212-L212) [[3]](diffhunk://#diff-dde629a17af2577782e565431419082c42ad932c0b667a69e1f650da47b89c16L229-R231)

**UI and Minor Cleanups:**

- Minor UI and state handling adjustments in `Masthead` and `ArticleCard` to align with the refactored logic and improve maintainability. [[1]](diffhunk://#diff-12ca3d5352126d9dcb88a6a2a01d64604ca9a26e4559f74662398793910eb508L54-L55) [[2]](diffhunk://#diff-12ca3d5352126d9dcb88a6a2a01d64604ca9a26e4559f74662398793910eb508L133-R131) [[3]](diffhunk://#diff-f080414ad504459441620a73eb88744c7ac558a2e198493ba38e7590d8381afeR17)

Overall, these changes improve code modularity, reduce duplication, and make data flow and UI logic easier to follow and maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Author names now display as @playerName across articles, notes, and editor steps.
  - Category pickers auto-populate from available categories.
  - Consistent distance and Set Waypoint actions across pages.

- UI
  - Pinned app: removed Close/Refresh; opening an article now also unpins.
  - Published list auto-sources your articles and labels ownership as “you.”
  - Back page anchor preview uses your current position when available.

- Refactor
  - Migrated pages/components to shared hooks for posts, categories, player name, position, and waypoint.

- Style
  - Minor whitespace adjustment in ArticleCard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->