### PR TITLE
feat: render collections

### DIFF
--- a/packages/app/src/Routes.tsx
+++ b/packages/app/src/Routes.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 
 import { ArticlePage } from "@/pages/ArticlePage";
 import { BackPage } from "@/pages/BackPage";
+import { CollectionPage } from "@/pages/CollectionPage";
 import { DiscoverPage } from "@/pages/DiscoverPage";
 import { EditorRoomPage } from "@/pages/EditorRoomPage";
 import { FrontPage } from "@/pages/FrontPage";
@@ -12,7 +13,8 @@ export const LOCAL_PAGE_PATH = "/local";
 export const BACK_PAGE_PATH = "/back-page";
 export const DISCOVER_PAGE_PATH = "/discover";
 export const EDITOR_PAGE_PATH = "/editor";
-export const ARTICLE_PAGE_PATH = "/article/";
+export const ARTICLE_PAGE_PATH = "/articles/";
+export const COLLECTION_PAGE_PATH = "/collections/";
 
 const AppRoutes: React.FC = () => {
   return (
@@ -23,6 +25,7 @@ const AppRoutes: React.FC = () => {
       <Route path={DISCOVER_PAGE_PATH} element={<DiscoverPage />} />
       <Route path={EDITOR_PAGE_PATH} element={<EditorRoomPage />} />
       <Route path={`${ARTICLE_PAGE_PATH}:id`} element={<ArticlePage />} />
+      <Route path={`${COLLECTION_PAGE_PATH}:id`} element={<CollectionPage />} />
     </Routes>
   );
 };

--- a/packages/app/src/components/CollectionCard.tsx
+++ b/packages/app/src/components/CollectionCard.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { cn } from "@/lib/utils";
+import { COLLECTION_PAGE_PATH } from "@/Routes";
+import { formatDate } from "@/utils/helpers";
+import type { Collection } from "@/utils/types";
+
+export const CollectionCard = ({ collection }: { collection: Collection }) => {
+  const [imgLoaded, setImgLoaded] = useState(false);
+
+  return (
+    <article className="relative">
+      <h3 className={cn("font-heading", "text-2xl leading-snug")}>
+        <Link
+          className="cursor-pointer hover:underline"
+          to={`${COLLECTION_PAGE_PATH}${encodeURIComponent(collection.id)}`}
+        >
+          {collection.title}
+        </Link>
+      </h3>
+      <div className="border border-neutral-900 my-2 overflow-hidden relative">
+        {/* shimmer placeholder while image loads */}
+        {!imgLoaded && (
+          <div
+            aria-hidden
+            className="absolute inset-0 bg-neutral-200"
+            style={{
+              backgroundImage:
+                "linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0) 100%)",
+              backgroundSize: "200% 100%",
+              animation: "shimmer 1.2s linear infinite",
+            }}
+          />
+        )}
+        <img
+          alt={collection.title}
+          src={collection.coverImage}
+          loading="lazy"
+          onLoad={() => setImgLoaded(true)}
+          className={`aspect-video grayscale hover:grayscale-0 object-cover w-full transition-all duration-500 ${
+            imgLoaded ? "opacity-100" : "opacity-0"
+          }`}
+          width={800}
+          height={450}
+        />
+        <style>{`@keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }`}</style>
+      </div>
+      <p className={"text-[15px] leading-relaxed text-neutral-800"}>
+        {collection.description.length > 50 ? (
+          <>{collection.description.slice(0, 50)}...</>
+        ) : (
+          collection.description
+        )}
+      </p>
+      <div className={cn("font-accent", "mt-1 text-[10px]")}>
+        By @{collection.author} on {formatDate(collection.createdAt)}
+      </div>
+    </article>
+  );
+};

--- a/packages/app/src/components/editor/CollectionWizard.tsx
+++ b/packages/app/src/components/editor/CollectionWizard.tsx
@@ -117,7 +117,7 @@ export const CollectionWizard: React.FC<CollectionWizardProps> = ({
         setCoverImage("");
         setArticleIds([]);
         onDone();
-        toast.success("Collection Published!");
+        toast.success("Collection Published! View in the Discover page.");
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error("Error publishing collection:", error);

--- a/packages/app/src/pages/CollectionPage.tsx
+++ b/packages/app/src/pages/CollectionPage.tsx
@@ -12,7 +12,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { stash, tables } from "@/mud/stash";
-import { DISCOVER_PAGE_PATH, FRONT_PAGE_PATH } from "@/Routes";
+import {
+  ARTICLE_PAGE_PATH,
+  DISCOVER_PAGE_PATH,
+  FRONT_PAGE_PATH,
+} from "@/Routes";
 import { formatDate, shortenAddress, uriToHttp } from "@/utils/helpers";
 import type { Collection } from "@/utils/types";
 
@@ -68,9 +72,13 @@ export const CollectionPage = () => {
   const collectionArticles = useMemo(() => {
     if (!collection) return [];
 
-    return articles.filter((article) =>
-      collection.articleIds.includes(article.id)
-    );
+    return articles
+      .filter((article) => collection.articleIds.includes(article.id))
+      .sort((a, b) => {
+        const aIndex = collection.articleIds.indexOf(a.id);
+        const bIndex = collection.articleIds.indexOf(b.id);
+        return aIndex - bIndex;
+      });
   }, [collection, articles]);
 
   if (!collection) {
@@ -156,7 +164,7 @@ export const CollectionPage = () => {
                     <div className="flex-1">
                       <h2 className={cn("font-heading", "mb-2 text-2xl")}>
                         <Link
-                          to={`/articles/${article.id}`}
+                          to={`${ARTICLE_PAGE_PATH}${article.id}`}
                           className="hover:underline"
                         >
                           {article.title}
@@ -215,7 +223,7 @@ export const CollectionPage = () => {
                   </div>
 
                   <div className="border-t border-neutral-200 mt-4 pt-4">
-                    <Link to={`/articles/${article.id}`}>
+                    <Link to={`${ARTICLE_PAGE_PATH}${article.id}`}>
                       <Button
                         className={cn("font-accent", "text-[10px]")}
                         size="sm"

--- a/packages/app/src/pages/CollectionPage.tsx
+++ b/packages/app/src/pages/CollectionPage.tsx
@@ -1,0 +1,247 @@
+import { getRecord } from "@latticexyz/stash/internal";
+import { useRecords } from "@latticexyz/stash/react";
+import { useMemo } from "react";
+import { Link, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { hexToString } from "viem";
+
+import { useCopy } from "@/common/useCopy";
+import { usePosts } from "@/common/usePosts";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { stash, tables } from "@/mud/stash";
+import { DISCOVER_PAGE_PATH, FRONT_PAGE_PATH } from "@/Routes";
+import { formatDate, shortenAddress, uriToHttp } from "@/utils/helpers";
+import type { Collection } from "@/utils/types";
+
+export const CollectionPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { copyToClipboard } = useCopy();
+  const { articles } = usePosts();
+
+  const collections = useRecords({
+    stash,
+    table: tables.Collection,
+  })
+    .map((r): Collection => {
+      const ownerName = getRecord({
+        stash,
+        table: tables.PlayerName,
+        key: { player: r.owner as `0x${string}` },
+      })?.name;
+
+      let author = "Anonymous";
+
+      if (ownerName) {
+        const decoded = hexToString(ownerName).replace(/\0+$/, "").trim();
+        if (decoded) author = decoded;
+      }
+
+      const articleIds = (getRecord({
+        stash,
+        table: tables.CollectionPosts,
+        key: { id: r.id as `0x${string}` },
+      })?.posts ?? []) as string[];
+
+      return {
+        id: r.id,
+        articleIds,
+        author,
+        coverImage:
+          uriToHttp(r.coverImage)[0] || "/assets/placeholder-notext.png",
+        createdAt: r.createdAt,
+        description: r.description,
+        owner: r.owner,
+        title: r.title,
+        updatedAt: r.updatedAt,
+      };
+    })
+    .sort((a, b) => Number(b.createdAt - a.createdAt));
+
+  const collection = useMemo(
+    () => collections.find((p) => p.id === id),
+    [id, collections]
+  );
+
+  const collectionArticles = useMemo(() => {
+    if (!collection) return [];
+
+    return articles.filter((article) =>
+      collection.articleIds.includes(article.id)
+    );
+  }, [collection, articles]);
+
+  if (!collection) {
+    return (
+      <div className="p-6">
+        <h1 className={cn("font-heading", "text-3xl")}>Collection not found</h1>
+        <p className="mt-2">
+          We couldn&apos;t find that collection. Try the Discover page.
+        </p>
+        <div className="mt-4">
+          <Link className="cursor-pointer underline" to={DISCOVER_PAGE_PATH}>
+            Go to Discover
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <article className="p-4 sm:p-6">
+      <header className="grid gap-3">
+        <div
+          className={cn(
+            "font-accent",
+            "text-neutral-700 text-[10px] uppercase tracking-widest"
+          )}
+        >
+          Collection
+        </div>
+        <h1
+          className={cn("font-heading", " sm:text-5xl text-4xl leading-tight")}
+        >
+          {collection.title}
+        </h1>
+
+        <div className={cn("font-accent", "text-neutral-700 text-[10px]")}>
+          {"By "}
+          <button
+            onClick={() => {
+              copyToClipboard(collection.owner);
+              toast.success(`Copied ${shortenAddress(collection.owner)}`);
+            }}
+          >
+            @{collection.author}
+          </button>
+          {" • "}
+          {formatDate(collection.createdAt)}
+        </div>
+      </header>
+
+      <p className="leading-relaxed mb-6 mt-4 text-lg text-neutral-700">
+        {collection.description}
+      </p>
+
+      {collection.coverImage && (
+        <div className="border border-neutral-900 my-4 overflow-hidden">
+          <img
+            alt={collection.title}
+            className="duration-500 grayscale hover:grayscale-0 object-cover transition-all w-full"
+            height={720}
+            src={collection.coverImage}
+            width={1200}
+          />
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {collectionArticles.map((article, index) => (
+          <Card key={article.id} className="border-neutral-900">
+            <CardContent className="p-6">
+              <div className="flex gap-6">
+                <div
+                  className={cn(
+                    "font-heading",
+                    "font-bold leading-none mt-[-15px] select-none text-neutral-300 text-6xl"
+                  )}
+                >
+                  {index + 1}
+                </div>
+
+                <div className="flex-1">
+                  <div className="flex gap-4">
+                    <div className="flex-1">
+                      <h2 className={cn("font-heading", "mb-2 text-2xl")}>
+                        <Link
+                          to={`/articles/${article.id}`}
+                          className="hover:underline"
+                        >
+                          {article.title}
+                        </Link>
+                      </h2>
+                      <p className="text-neutral-700 leading-relaxed mb-3">
+                        {article.excerpt}
+                      </p>
+                      <div className="flex gap-4 items-center text-neutral-600 text-sm">
+                        <span
+                          className={cn(
+                            "font-accent",
+                            "text-[10px] uppercase tracking-widest"
+                          )}
+                        >
+                          By {article.author}
+                        </span>
+                        <span
+                          className={cn(
+                            "font-accent",
+                            "text-[10px] uppercase tracking-widest"
+                          )}
+                        >
+                          {formatDate(article.createdAt)}
+                        </span>
+                      </div>
+                      {article.categories && (
+                        <div className="flex gap-1 mt-2">
+                          {article.categories.map((category) => (
+                            <Badge
+                              key={category}
+                              className={cn(
+                                "font-accent",
+                                "px-2 py-0.5 text-[8px]"
+                              )}
+                              variant="outline"
+                            >
+                              {category}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
+                    {article.coverImage && (
+                      <div className="border border-neutral-300 flex-shrink-0 overflow-hidden h-24 w-32">
+                        <img
+                          alt={article.title}
+                          className="grayscale h-full object-cover w-full"
+                          height={96}
+                          src={article.coverImage || "/placeholder.svg"}
+                          width={128}
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="border-t border-neutral-200 mt-4 pt-4">
+                    <Link to={`/articles/${article.id}`}>
+                      <Button
+                        className={cn("font-accent", "text-[10px]")}
+                        size="sm"
+                        variant="outline"
+                      >
+                        Read Full Story
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <footer className="border-neutral-900 border-t flex flex-wrap gap-3 items-center justify-between mt-6 pt-3">
+        <div className="flex gap-3">
+          <Link to={FRONT_PAGE_PATH} className="underline">
+            Front Page
+          </Link>
+          <Link to={DISCOVER_PAGE_PATH} className="underline">
+            Discover
+          </Link>
+        </div>
+      </footer>
+    </article>
+  );
+};

--- a/packages/app/src/pages/DiscoverPage.tsx
+++ b/packages/app/src/pages/DiscoverPage.tsx
@@ -84,13 +84,17 @@ export const DiscoverPage = () => {
         .map((res) => res.item);
     }
 
+    if (selectedCategory) {
+      results = results.filter((a) => a.categories.includes(selectedCategory));
+    }
+
     results.sort((a, b) => {
       if (dateSort === "newest") return Number(b.createdAt - a.createdAt);
       return Number(a.createdAt - b.createdAt);
     });
 
     return results;
-  }, [articles, searchQuery, dateSort]);
+  }, [articles, dateSort, searchQuery, selectedCategory]);
 
   const filteredCollections = useMemo(() => {
     const term = searchQuery.trim().toLowerCase();
@@ -112,7 +116,7 @@ export const DiscoverPage = () => {
     });
 
     return results;
-  }, [collections, searchQuery, dateSort]);
+  }, [collections, dateSort, searchQuery]);
 
   return (
     <div className="gap-6 p-4 sm:p-6 grid">

--- a/packages/app/src/pages/DiscoverPage.tsx
+++ b/packages/app/src/pages/DiscoverPage.tsx
@@ -1,14 +1,24 @@
+import { getRecord } from "@latticexyz/stash/internal";
+import { useRecords } from "@latticexyz/stash/react";
+import Fuse from "fuse.js";
 import { useMemo, useState } from "react";
+import { hexToString } from "viem";
 
 import { useCategories } from "@/common/useCategories";
 import { useDustClient } from "@/common/useDustClient";
 import { usePosts } from "@/common/usePosts";
 import { useWaypoint } from "@/common/useWaypoint";
 import { ArticleCard } from "@/components/ArticleCard";
+import { CollectionCard } from "@/components/CollectionCard";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { stash, tables } from "@/mud/stash";
+import { uriToHttp } from "@/utils/helpers";
+import type { Collection } from "@/utils/types";
+
+type ContentType = "articles" | "collections";
 
 export const DiscoverPage = () => {
   const { data: dustClient } = useDustClient();
@@ -16,38 +26,62 @@ export const DiscoverPage = () => {
   const { articleCategories } = useCategories();
   const { onSetWaypoint } = useWaypoint();
 
-  const [q, setQ] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [contentType, setContentType] = useState<ContentType>("articles");
+
   const [selectedCategory, setSelectedCategory] = useState<string>("");
-  const [authorFilter, setAuthorFilter] = useState<string>("");
   const [dateSort, setDateSort] = useState<"newest" | "oldest">("newest");
 
-  const filteredArticles = useMemo(() => {
-    const term = q.trim().toLowerCase();
+  const collections = useRecords({
+    stash,
+    table: tables.Collection,
+  })
+    .map((r): Collection => {
+      const ownerName = getRecord({
+        stash,
+        table: tables.PlayerName,
+        key: { player: r.owner as `0x${string}` },
+      })?.name;
 
+      let author = "Anonymous";
+
+      if (ownerName) {
+        const decoded = hexToString(ownerName).replace(/\0+$/, "").trim();
+        if (decoded) author = decoded;
+      }
+
+      const articleIds = (getRecord({
+        stash,
+        table: tables.CollectionPosts,
+        key: { id: r.id as `0x${string}` },
+      })?.posts ?? []) as string[];
+
+      return {
+        id: r.id,
+        articleIds,
+        author,
+        coverImage:
+          uriToHttp(r.coverImage)[0] || "/assets/placeholder-notext.png",
+        createdAt: r.createdAt,
+        description: r.description,
+        owner: r.owner,
+        title: r.title,
+        updatedAt: r.updatedAt,
+      };
+    })
+    .sort((a, b) => Number(b.createdAt - a.createdAt));
+
+  const filteredArticles = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase();
     let results = articles.slice();
 
-    if (selectedCategory) {
-      results = results.filter((a) =>
-        (a.categories || []).includes(selectedCategory)
-      );
-    }
-
-    if (authorFilter.trim()) {
-      const af = authorFilter.trim().toLowerCase();
-      results = results.filter((a) =>
-        (a.owner || "").toLowerCase().includes(af)
-      );
-    }
-
     if (term) {
-      results = results.filter(
-        (a) =>
-          (a.title || "").toLowerCase().includes(term) ||
-          (a.excerpt || "").toLowerCase().includes(term) ||
-          (a.categories || []).some((cat: string) =>
-            cat.toLowerCase().includes(term)
-          )
-      );
+      results = new Fuse(articles, {
+        keys: ["author", "categories", "excerpt", "title"],
+        includeScore: true,
+      })
+        .search(term)
+        .map((res) => res.item);
     }
 
     results.sort((a, b) => {
@@ -56,7 +90,29 @@ export const DiscoverPage = () => {
     });
 
     return results;
-  }, [articles, q, selectedCategory, authorFilter, dateSort]);
+  }, [articles, searchQuery, dateSort]);
+
+  const filteredCollections = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase();
+
+    let results = collections.slice();
+
+    if (term) {
+      results = new Fuse(collections, {
+        keys: ["author", "description", "title"],
+        includeScore: true,
+      })
+        .search(term)
+        .map((res) => res.item);
+    }
+
+    results.sort((a, b) => {
+      if (dateSort === "newest") return Number(b.createdAt - a.createdAt);
+      return Number(a.createdAt - b.createdAt);
+    });
+
+    return results;
+  }, [collections, searchQuery, dateSort]);
 
   return (
     <div className="gap-6 p-4 sm:p-6 grid">
@@ -65,18 +121,13 @@ export const DiscoverPage = () => {
           <h1 className={cn("font-heading", "text-3xl")}>Discover</h1>
           <p className="text-neutral-700 text-sm">Search all articles</p>
         </div>
+
         <div className="flex gap-2 items-end">
           <Input
             className="border-neutral-900 max-w-xs"
-            onChange={(e) => setQ(e.target.value)}
+            onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search stories..."
-            value={q}
-          />
-          <Input
-            className="border-neutral-900 max-w-xs"
-            onChange={(e) => setAuthorFilter(e.target.value)}
-            placeholder="Filter by author..."
-            value={authorFilter}
+            value={searchQuery}
           />
           <select
             className={cn(
@@ -93,59 +144,111 @@ export const DiscoverPage = () => {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        <Button
-          className="border-neutral-900"
-          onClick={() => setSelectedCategory("")}
-          size="sm"
-          variant={selectedCategory === "" ? "default" : "outline"}
+      <div className="flex gap-1 border-b border-neutral-300">
+        <button
+          className={cn(
+            "font-accent",
+            "border-b-2 px-4 py-2 text-[10px] uppercase tracking-widest transition-colors",
+            contentType === "articles"
+              ? "border-neutral-900 text-neutral-900"
+              : "border-transparent text-neutral-500 hover:text-neutral-700"
+          )}
+          onClick={() => setContentType("articles")}
         >
-          All Categories
-        </Button>
-        {articleCategories.map((category) => (
-          <Button
-            key={category}
-            className="border-neutral-900"
-            onClick={() => setSelectedCategory(category)}
-            size="sm"
-            variant={selectedCategory === category ? "default" : "outline"}
-          >
-            {category}
-          </Button>
-        ))}
+          Articles
+        </button>
+        <button
+          className={cn(
+            "font-accent",
+            "border-b-2 px-4 py-2 text-[10px] uppercase tracking-widest transition-colors",
+            contentType === "collections"
+              ? "border-neutral-900 text-neutral-900"
+              : "border-transparent text-neutral-500 hover:text-neutral-700"
+          )}
+          onClick={() => setContentType("collections")}
+        >
+          Collections
+        </button>
       </div>
 
-      <Card className="border-neutral-900">
-        <CardContent className="p-4">
-          <div className="gap-6 grid md:grid-cols-2">
-            {filteredArticles.map((a) => (
-              <div key={a.id} className="border-neutral-900 border-t pt-3">
-                <ArticleCard article={a} />
-                {a.distance !== null && (
-                  <div className={cn("font-accent", "mt-2 text-[10px]")}>
-                    Distance: {a.distance} blocks{" "}
-                    {dustClient && (
-                      <span>
-                        •{" "}
-                        <button
-                          onClick={() => onSetWaypoint(a)}
-                          className="underline"
-                          disabled={!dustClient}
-                        >
-                          Set Waypoint
-                        </button>
-                      </span>
+      {contentType === "articles" && (
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              className="border-neutral-900"
+              onClick={() => setSelectedCategory("")}
+              size="sm"
+              variant={selectedCategory === "" ? "default" : "outline"}
+            >
+              All Categories
+            </Button>
+            {articleCategories.map((category) => (
+              <Button
+                key={category}
+                className="border-neutral-900"
+                onClick={() => setSelectedCategory(category)}
+                size="sm"
+                variant={selectedCategory === category ? "default" : "outline"}
+              >
+                {category}
+              </Button>
+            ))}
+          </div>
+
+          <Card className="border-neutral-900">
+            <CardContent className="p-4">
+              <div className="gap-6 grid md:grid-cols-2">
+                {filteredArticles.map((a) => (
+                  <div key={a.id} className="border-neutral-900 border-t pt-3">
+                    <ArticleCard article={a} />
+                    {a.distance !== null && (
+                      <div className={cn("font-accent", "mt-2 text-[10px]")}>
+                        Distance: {a.distance} blocks{" "}
+                        {dustClient && (
+                          <span>
+                            •{" "}
+                            <button
+                              onClick={() => onSetWaypoint(a)}
+                              className="underline"
+                              disabled={!dustClient}
+                            >
+                              Set Waypoint
+                            </button>
+                          </span>
+                        )}
+                      </div>
                     )}
+                  </div>
+                ))}
+                {filteredArticles.length === 0 && (
+                  <div className="text-neutral-600 text-sm">
+                    No results found.
                   </div>
                 )}
               </div>
-            ))}
-            {filteredArticles.length === 0 && (
-              <div className="text-neutral-600 text-sm">No results found.</div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {contentType === "collections" && (
+        <Card className="border-neutral-900">
+          <CardContent className="p-4">
+            <div className="gap-6 grid md:grid-cols-2">
+              {filteredCollections.map((a) => (
+                <div key={a.id} className="border-neutral-900 border-t pt-3">
+                  <CollectionCard collection={a} />
+                </div>
+              ))}
+              {filteredCollections.length === 0 && (
+                <div className="text-neutral-600 text-sm">
+                  No results found.
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 };

--- a/packages/app/src/pages/EditorRoomPage.tsx
+++ b/packages/app/src/pages/EditorRoomPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { useDustClient } from "@/common/useDustClient";
 import { ArticleWizard } from "@/components/editor/ArticleWizard";
 import { CollectionWizard } from "@/components/editor/CollectionWizard";
 import { PublishedList } from "@/components/editor/PublishedList";
@@ -26,8 +27,11 @@ const loadDrafts = () => {
   }
 };
 
+type TabKey = "published" | "drafts";
+
 export const EditorRoomPage = () => {
-  type TabKey = "published" | "drafts";
+  const { data: dustClient } = useDustClient();
+
   const [tab, setTab] = useState<TabKey>("published");
 
   const TabButton = ({ k, label }: { k: TabKey; label: string }) => (
@@ -113,6 +117,14 @@ export const EditorRoomPage = () => {
     setWizardDraftId(undefined);
     setDrafts(loadDrafts());
   };
+
+  if (!dustClient) {
+    return (
+      <div className="p-4">
+        Please open the app in DUST to use the Editor Room.
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4 p-4">

--- a/packages/app/src/pages/EditorRoomPage.tsx
+++ b/packages/app/src/pages/EditorRoomPage.tsx
@@ -30,7 +30,7 @@ const loadDrafts = () => {
 type TabKey = "published" | "drafts";
 
 export const EditorRoomPage = () => {
-  const { data: dustClient } = useDustClient();
+  const { data: dustClient, isLoading } = useDustClient();
 
   const [tab, setTab] = useState<TabKey>("published");
 
@@ -117,6 +117,10 @@ export const EditorRoomPage = () => {
     setWizardDraftId(undefined);
     setDrafts(loadDrafts());
   };
+
+  if (isLoading) {
+    return <div className="p-4">Loading...</div>;
+  }
 
   if (!dustClient) {
     return (

--- a/packages/app/src/utils/types.ts
+++ b/packages/app/src/utils/types.ts
@@ -1,3 +1,15 @@
+export type Collection = {
+  id: string;
+  articleIds: string[];
+  author: string;
+  coverImage: string;
+  createdAt: bigint;
+  description: string;
+  owner: string;
+  title: string;
+  updatedAt: bigint;
+};
+
 export type Post = {
   id: string;
   author: string;


### PR DESCRIPTION
This pull request introduces support for "collections" in the application, allowing users to view, search, and interact with grouped sets of articles. The main changes include adding new types and components for collections, updating routing to support collection pages, and enhancing the Discover page to browse both articles and collections. Additionally, there are minor UX improvements and some refactoring.

**Collections Feature Implementation**

* Added a new `Collection` type to `utils/types.ts`, representing a group of articles with metadata such as title, description, cover image, author, and timestamps.
* Created a new `CollectionCard` component for displaying collection summaries, including cover image, description, and author.
* Added a new `CollectionPage` component that displays the details of a collection and its articles, with navigation and copy-to-clipboard functionality for the author's address.

**Routing Updates**

* Updated `Routes.tsx` to include a route for individual collection pages (`/collections/:id`) and adjusted the articles route to `/articles/:id`. [[1]](diffhunk://#diff-484b88a52bd2a6a64ab692674cf7c343ce2e6b82069035d8317ec4ab70bc0033R5) [[2]](diffhunk://#diff-484b88a52bd2a6a64ab692674cf7c343ce2e6b82069035d8317ec4ab70bc0033L15-R17) [[3]](diffhunk://#diff-484b88a52bd2a6a64ab692674cf7c343ce2e6b82069035d8317ec4ab70bc0033R28)

**Discover Page Enhancements**

* Enhanced the Discover page to allow users to toggle between browsing articles and collections, including search and sorting functionality for both content types. Integrated the new `CollectionCard` for collection display. [[1]](diffhunk://#diff-0e812726271eae99dab876e02b01755cde02966d56369cc1a7d281741c8b7a3eR1-R106) [[2]](diffhunk://#diff-0e812726271eae99dab876e02b01755cde02966d56369cc1a7d281741c8b7a3eL59-R115) [[3]](diffhunk://#diff-0e812726271eae99dab876e02b01755cde02966d56369cc1a7d281741c8b7a3eR124-R130) [[4]](diffhunk://#diff-0e812726271eae99dab876e02b01755cde02966d56369cc1a7d281741c8b7a3eR147-R175) [[5]](diffhunk://#diff-0e812726271eae99dab876e02b01755cde02966d56369cc1a7d281741c8b7a3eL144-R252)

**Editor Room and UX Improvements**

* Added a check in the Editor Room to ensure the user is running the app in DUST, displaying a message if not. [[1]](diffhunk://#diff-1138681615d8c89a8caf4267e0091d973e297374dd283be64770722c9659d41cR3) [[2]](diffhunk://#diff-1138681615d8c89a8caf4267e0091d973e297374dd283be64770722c9659d41cL29-R34) [[3]](diffhunk://#diff-1138681615d8c89a8caf4267e0091d973e297374dd283be64770722c9659d41cR121-R128)
* Improved the toast message after publishing a collection to suggest viewing it in the Discover page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Browse and view Collections with a dedicated Collection page, Collection cards, and a public route for collections.
  - Discover now supports toggling between Articles and Collections, with unified search and improved sorting/filtering.
  - Editor Room integrates DUST detection and shows guidance when not available.
  - Article URLs standardized to /articles/:id.

- Improvements
  - Publishing a collection shows a success toast linking users to Discover.
- API
  - Added a public Collection data type for use across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->